### PR TITLE
Improve score ring rendering

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -444,12 +444,15 @@ function ringColor(label) {
 }
 
 function updateRing(percent, label) {
-  const degrees = Math.max(0, Math.min(100, percent)) * 3.6;
   const color = ringColor(label);
-  document.documentElement.style.setProperty('--ring-angle', `${degrees}deg`);
+  const circumference = 314.16;
+  const offset = circumference * (1 - Math.max(0, Math.min(100, percent)) / 100);
   document.documentElement.style.setProperty('--ring-color', color);
-  document.querySelector('.score-ring').style.background =
-    `radial-gradient(circle at center, rgba(16, 21, 18, 0.95) 44%, transparent 46%), conic-gradient(${color} ${degrees}deg, rgba(255, 255, 255, 0.08) 0deg)`;
+  const fill = document.querySelector('.score-ring__fill');
+  if (fill) {
+    fill.style.stroke = color;
+    fill.style.strokeDashoffset = offset;
+  }
 }
 
 function redirectToLanding() {

--- a/public/app.js
+++ b/public/app.js
@@ -436,11 +436,20 @@ function healthClass(label) {
   return 'status-poor';
 }
 
-function updateRing(percent) {
+function ringColor(label) {
+  if (label === 'VERY HEALTHY' || label === 'GOOD') return 'var(--good)';
+  if (label === 'FAIR') return 'var(--fair)';
+  if (!label || label === 'Waiting') return 'var(--accent-strong)';
+  return 'var(--poor)';
+}
+
+function updateRing(percent, label) {
   const degrees = Math.max(0, Math.min(100, percent)) * 3.6;
+  const color = ringColor(label);
   document.documentElement.style.setProperty('--ring-angle', `${degrees}deg`);
+  document.documentElement.style.setProperty('--ring-color', color);
   document.querySelector('.score-ring').style.background =
-    `radial-gradient(circle at center, rgba(16, 21, 18, 0.95) 50%, transparent 52%), conic-gradient(var(--accent-strong) ${degrees}deg, rgba(255, 255, 255, 0.08) 0deg)`;
+    `radial-gradient(circle at center, rgba(16, 21, 18, 0.95) 44%, transparent 46%), conic-gradient(${color} ${degrees}deg, rgba(255, 255, 255, 0.08) 0deg)`;
 }
 
 function redirectToLanding() {
@@ -963,7 +972,7 @@ function render() {
     setSessionHash('');
     ui.healthLabel.textContent = 'Waiting';
     ui.healthLabel.className = '';
-    ui.healthPercent.textContent = '0%';
+    ui.healthPercent.innerHTML = '<span class="score-num">0</span><span class="score-unit">%</span>';
     ui.observedCount.textContent = '0 / 0';
     ui.senderName.textContent = 'Pending';
     ui.channelName.textContent = channelLabel;
@@ -976,7 +985,7 @@ function render() {
     renderReceiptTimeline(null);
     renderReceipts(null);
     renderHistory(historySessions);
-    updateRing(0);
+    updateRing(0, 'Waiting');
     return;
   }
 
@@ -992,7 +1001,7 @@ function render() {
   setSessionHash(session.messageHash);
   ui.healthLabel.textContent = session.healthLabel;
   ui.healthLabel.className = healthClass(session.healthLabel);
-  ui.healthPercent.textContent = `${session.healthPercent}%`;
+  ui.healthPercent.innerHTML = `<span class="score-num">${session.healthPercent}</span><span class="score-unit">%</span>`;
   ui.observedCount.textContent = `${session.observedCount} / ${session.expectedCount}`;
   ui.senderName.textContent = session.sender || 'Pending';
   ui.channelName.textContent = session.channelName ? `#${session.channelName}` : channelLabel;
@@ -1003,7 +1012,7 @@ function render() {
     ? targetPreviewLabel()
     : sessionObserverSourceLabel(session);
 
-  updateRing(session.healthPercent);
+  updateRing(session.healthPercent, session.healthLabel);
   renderObserverAllowlist();
   renderExpectedObservers(showTargetPreview ? targetPreviewSession() : session);
   renderObserverMap(session);

--- a/public/index.html
+++ b/public/index.html
@@ -87,7 +87,7 @@
               <h2 id="health-label">Waiting</h2>
             </div>
             <div class="score-ring">
-              <span id="health-percent">0%</span>
+              <span id="health-percent"><span class="score-num">0</span><span class="score-unit">%</span></span>
             </div>
           </div>
           <div class="score-grid">

--- a/public/index.html
+++ b/public/index.html
@@ -87,6 +87,10 @@
               <h2 id="health-label">Waiting</h2>
             </div>
             <div class="score-ring">
+              <svg class="score-ring__svg" viewBox="0 0 120 120" aria-hidden="true">
+                <circle class="score-ring__track" cx="60" cy="60" r="50"/>
+                <circle class="score-ring__fill" cx="60" cy="60" r="50"/>
+              </svg>
               <span id="health-percent"><span class="score-num">0</span><span class="score-unit">%</span></span>
             </div>
           </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -247,18 +247,30 @@ body {
 }
 
 .score-ring {
-  width: 112px;
-  height: 112px;
+  width: 120px;
+  height: 120px;
   border-radius: 50%;
   display: grid;
   place-items: center;
   background:
-    radial-gradient(circle at center, rgba(16, 21, 18, 0.95) 50%, transparent 52%),
-    conic-gradient(var(--accent-strong) 0deg, rgba(255, 255, 255, 0.08) 0deg);
+    radial-gradient(circle at center, rgba(16, 21, 18, 0.95) 44%, transparent 46%),
+    conic-gradient(var(--ring-color, var(--accent-strong)) 0deg, rgba(255, 255, 255, 0.08) 0deg);
   border: 1px solid var(--line);
   font-family: "Courier New", monospace;
-  font-size: 1.35rem;
   font-weight: 700;
+  line-height: 1;
+}
+
+.score-num {
+  font-size: 1.65rem;
+  color: var(--ring-color, var(--accent-strong));
+  transition: color 0.4s ease;
+}
+
+.score-unit {
+  font-size: 0.75rem;
+  opacity: 0.7;
+  vertical-align: super;
 }
 
 .score-grid {

--- a/public/styles.css
+++ b/public/styles.css
@@ -249,25 +249,47 @@ body {
 .score-ring {
   width: 120px;
   height: 120px;
-  border-radius: 50%;
+  position: relative;
   display: grid;
   place-items: center;
-  background:
-    radial-gradient(circle at center, rgba(16, 21, 18, 0.95) 44%, transparent 46%),
-    conic-gradient(var(--ring-color, var(--accent-strong)) 0deg, rgba(255, 255, 255, 0.08) 0deg);
-  border: 1px solid var(--line);
   font-family: "Courier New", monospace;
   font-weight: 700;
   line-height: 1;
 }
 
+.score-ring__svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+.score-ring__track {
+  fill: none;
+  stroke: rgba(255, 255, 255, 0.08);
+  stroke-width: 8;
+}
+
+.score-ring__fill {
+  fill: none;
+  stroke: var(--ring-color, var(--accent-strong));
+  stroke-width: 8;
+  stroke-linecap: round;
+  stroke-dasharray: 314.16;
+  stroke-dashoffset: 314.16;
+  transition: stroke-dashoffset 0.5s ease, stroke 0.4s ease;
+}
+
 .score-num {
+  position: relative;
   font-size: 1.65rem;
   color: var(--ring-color, var(--accent-strong));
   transition: color 0.4s ease;
 }
 
 .score-unit {
+  position: relative;
   font-size: 0.75rem;
   opacity: 0.7;
   vertical-align: super;


### PR DESCRIPTION
## Summary

Improves the current health score ring rendering and layout.

This PR:
- colors the ring and percentage number from the current health label
- splits the percentage into number/unit spans for cleaner typography
- replaces the conic-gradient ring with SVG stroke rendering
- uses stroke-dashoffset to represent the health percentage
- keeps the ring markup stable and avoids the black/filled-circle rendering artifact seen with the previous CSS ring approach

## Behavior

The score ring still displays the same health percentage and status. The change is visual/rendering only: the fill is now driven by the existing frontend update path using the SVG circle stroke.

## Verification

- npm run check
- npm test