### PR TITLE
Add optional expected-observer map scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ If Turnstile is enabled:
 
 - The message hash in the active session card links directly to the packet
   analyzer when a hash is available.
+- By default, the coverage map plots the current observer directory. Custom
+  deployments can set `data-map-observer-scope="expected"` on the page `<body>`
+  to plot only the observer set used for the active session score.
 - The current session card includes a `Share` button that copies a retained
   `/share/:sessionId` link.
 - The coverage map defaults to dark tiles and can be toggled to light tiles in

--- a/public/app.js
+++ b/public/app.js
@@ -53,6 +53,9 @@ const ui = {
 };
 
 const pageMode = document.body?.dataset?.pageMode || 'app';
+const mapObserverScope = document.body?.dataset?.mapObserverScope === 'expected'
+  ? 'expected'
+  : 'directory';
 
 localStorage.removeItem(SESSION_STORAGE_KEY);
 localStorage.removeItem(SESSION_HISTORY_STORAGE_KEY);
@@ -708,14 +711,33 @@ function applySiteBranding(snapshot) {
 
 function mapKnownObservers(session) {
   const directory = observerDirectory();
+  let source = directory;
+  if (mapObserverScope === 'expected') {
+    const directoryByKey = new Map(directory.map((observer) => [observer.key, observer]));
+    const expected = Array.isArray(session?.expectedObservers)
+      ? session.expectedObservers.filter((observer) => observer?.key)
+      : [];
+    if (expected.length > 0) {
+      source = expected.map((observer) => {
+        const known = directoryByKey.get(observer.key) || fallbackObserverRecord(observer.key);
+        return {
+          ...known,
+          ...observer,
+          lat: known.lat,
+          lon: known.lon,
+          hasLocation: known.hasLocation,
+        };
+      });
+    }
+  }
   const seenKeys = new Set(
     Array.isArray(session?.receipts) ? session.receipts.map((receipt) => receipt.observerKey) : [],
   );
-  return directory
+  return source
     .filter((observer) => observer.lat != null && observer.lon != null)
     .map((observer) => ({
       ...observer,
-      seen: seenKeys.has(observer.key),
+      seen: Boolean(observer.seen) || seenKeys.has(observer.key),
     }));
 }
 


### PR DESCRIPTION
## Summary

Adds an optional frontend hook for deployments that want the coverage map to use the same observer set as the active session score.

By default, the map continues to plot the current observer directory, preserving the stock behavior.

Deployments can opt in with:

```html
<body data-map-observer-scope="expected">
```

When enabled, the map builds its marker set from the session's `expectedObservers` and joins those entries to the live observer directory for saved coordinates. Receipt data still controls whether each mapped observer is marked seen or missed.

## Why

Some deployments use a selected/default scoring set that is smaller than the full current observer directory. In those cases, the score can show a denominator like `12/18` while the map says `12/28 mapped observers reached`.

This option lets deployments align the map denominator with the score denominator without changing default behavior for existing installations.

## Notes

- Existing deployments are unaffected unless they add `data-map-observer-scope="expected"`.
- The fallback behavior remains the current observer directory.
- The README documents the opt-in hook.

## Verification

- npm run check
- npm test