### PR TITLE
[codex] Redesign dashboard theme and splash backgrounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,3 +163,13 @@ The app now uses `@michaelhart/meshcore-decoder` for runtime MeshCore packet
 decoding. The current upstream package already handles multibyte path-hop data,
 and this repo applies a small postinstall compatibility patch so the published
 CommonJS build still loads cleanly on Node 18.
+
+## Star History
+
+<a href="https://www.star-history.com/?repos=yellowcooln%2Fmeshcore-health-check&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=yellowcooln/meshcore-health-check&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=yellowcooln/meshcore-health-check&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=yellowcooln/meshcore-health-check&type=date&legend=top-left" />
+ </picture>
+</a>

--- a/public/app.js
+++ b/public/app.js
@@ -1,13 +1,14 @@
 const SESSION_STORAGE_KEY = 'mesh-health-check-session-id';
 const SESSION_HISTORY_STORAGE_KEY = 'mesh-health-check-session-history';
 const OBSERVER_ALLOWLIST_STORAGE_KEY = 'mesh-health-check-observer-allowlist';
-const MAP_THEME_STORAGE_KEY = 'mesh-health-check-map-theme';
+const UI_THEME_STORAGE_KEY = 'mesh-health-check-ui-theme';
 const ANALYZER_BASE_URL = 'https://analyzer.letsmesh.net/packets?packet_hash=';
 const SHARE_ROUTE_PREFIX = '/share/';
 let deferredInstallPrompt = null;
 
 const ui = {
   mqttPill: document.querySelector('#mqtt-pill'),
+  actionMenu: document.querySelector('#action-menu'),
   installAppButton: document.querySelector('#install-app-button'),
   newSessionButton: document.querySelector('#new-session-button'),
   copySessionCodeButton: document.querySelector('#copy-session-code'),
@@ -28,6 +29,7 @@ const ui = {
   heroDescriptionSuffix: document.querySelector('#hero-description-suffix'),
   heroChannel: document.querySelector('#hero-channel'),
   brokerName: document.querySelector('#broker-name'),
+  modeLabel: document.querySelector('#mode-label'),
   externalLink: document.querySelector('#external-link'),
   repoNoteLink: document.querySelector('#repo-note-link'),
   siteVersionNote: document.querySelector('#site-version-note'),
@@ -37,7 +39,7 @@ const ui = {
   observerAllowlistNote: document.querySelector('#observer-allowlist-note'),
   observerAllowlist: document.querySelector('#observer-allowlist'),
   observerAllowlistClear: document.querySelector('#observer-allowlist-clear'),
-  mapThemeToggle: document.querySelector('#map-theme-toggle'),
+  uiThemeToggle: document.querySelector('#ui-theme-toggle'),
   mapObserverNote: document.querySelector('#map-observer-note'),
   mapEmpty: document.querySelector('#map-empty'),
   observerMap: document.querySelector('#observer-map'),
@@ -51,6 +53,25 @@ const ui = {
   receiptsEmpty: document.querySelector('#receipts-empty'),
   receipts: document.querySelector('#receipts'),
   sessionHistory: document.querySelector('#session-history'),
+  networkWindow: document.querySelector('#network-window'),
+  networkState: document.querySelector('#network-state'),
+  observerDensity: document.querySelector('#observer-density'),
+  observerDensityLabel: document.querySelector('#observer-density-label'),
+  observerDensityDetail: document.querySelector('#observer-density-detail'),
+  observerSparkline: document.querySelector('#observer-sparkline'),
+  observerLoadSparkline: document.querySelector('#observer-load-sparkline'),
+  signalQuality: document.querySelector('#signal-quality'),
+  signalQualityLabel: document.querySelector('#signal-quality-label'),
+  signalSparkline: document.querySelector('#signal-sparkline'),
+  latencyScore: document.querySelector('#latency-score'),
+  latencyLabel: document.querySelector('#latency-label'),
+  latencySparkline: document.querySelector('#latency-sparkline'),
+  detailDrawer: document.querySelector('#detail-drawer'),
+  drawerScrim: document.querySelector('#drawer-scrim'),
+  drawerMeta: document.querySelector('#drawer-meta'),
+  drawerTitle: document.querySelector('#drawer-title'),
+  drawerBody: document.querySelector('#drawer-body'),
+  drawerClose: document.querySelector('#drawer-close'),
 };
 
 const pageMode = document.body?.dataset?.pageMode || 'app';
@@ -68,7 +89,7 @@ const state = {
   sharedSessionMissing: false,
   trackedSessionIds: loadTrackedSessionIds(),
   selectedObserverKeys: loadSelectedObserverKeys(),
-  mapTheme: loadMapTheme(),
+  uiTheme: loadUiTheme(),
   sessions: new Map(),
   socket: null,
   socketRetryTimer: 0,
@@ -80,6 +101,10 @@ const state = {
     layerTheme: '',
     markers: new Map(),
     boundsKey: '',
+  },
+  drawer: {
+    kind: '',
+    key: '',
   },
 };
 
@@ -123,17 +148,48 @@ function saveSelectedObserverKeys() {
   );
 }
 
-function loadMapTheme() {
-  const stored = localStorage.getItem(MAP_THEME_STORAGE_KEY);
+function loadUiTheme() {
+  const stored = localStorage.getItem(UI_THEME_STORAGE_KEY);
   return stored === 'light' ? 'light' : 'dark';
 }
 
-function saveMapTheme() {
-  localStorage.setItem(MAP_THEME_STORAGE_KEY, state.mapTheme);
+function saveUiTheme() {
+  localStorage.setItem(UI_THEME_STORAGE_KEY, state.uiTheme);
+}
+
+function applyUiTheme() {
+  const activeTheme = state.uiTheme === 'dark' ? 'dark' : 'light';
+  document.body.dataset.uiTheme = activeTheme;
+  document.documentElement.style.colorScheme = activeTheme;
+  if (ui.uiThemeToggle) {
+    ui.uiThemeToggle.textContent = activeTheme === 'dark' ? 'Light Mode' : 'Dark Mode';
+  }
+  if (ui.modeLabel) {
+    ui.modeLabel.textContent = isSharePage()
+      ? (activeTheme === 'dark' ? 'Dark Review Surface' : 'Bright Review Surface')
+      : (activeTheme === 'dark' ? 'Dark Command Surface' : 'Bright Command Surface');
+  }
+  const metaThemeColor = document.querySelector('meta[name="theme-color"]');
+  if (metaThemeColor) {
+    metaThemeColor.setAttribute('content', activeTheme === 'dark' ? '#07111d' : '#e9f2ff');
+  }
 }
 
 function dedupe(items) {
   return [...new Set(items.filter(Boolean))];
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
 }
 
 function sharedSessionIdFromLocation() {
@@ -400,6 +456,206 @@ function formatElapsed(ms) {
   return `${minutes} min ${seconds}s`;
 }
 
+function formatWindow(seconds) {
+  const value = Math.max(0, Number(seconds) || 0);
+  if (value >= 3600) {
+    const hours = value / 3600;
+    return Number.isInteger(hours) ? `${hours}h window` : `${hours.toFixed(1)}h window`;
+  }
+  if (value >= 60) {
+    const minutes = value / 60;
+    return Number.isInteger(minutes) ? `${minutes}m window` : `${minutes.toFixed(1)}m window`;
+  }
+  return `${value}s window`;
+}
+
+function renderSparkline(element, points, tone = 'neutral') {
+  if (!element) {
+    return;
+  }
+  element.innerHTML = '';
+  element.dataset.tone = tone;
+  const source = Array.isArray(points) && points.length > 0
+    ? points
+    : [10, 12, 11, 14, 13, 12, 15, 12];
+  for (const [index, point] of source.entries()) {
+    const bar = document.createElement('span');
+    bar.className = 'sparkline-bar';
+    bar.style.height = `${clamp(point, 8, 100)}%`;
+    bar.style.animationDelay = `${index * 40}ms`;
+    element.appendChild(bar);
+  }
+}
+
+function scoreTone(score) {
+  if (!Number.isFinite(score)) {
+    return 'neutral';
+  }
+  if (score >= 72) {
+    return 'good';
+  }
+  if (score >= 45) {
+    return 'warning';
+  }
+  return 'critical';
+}
+
+function scoreLabel(score) {
+  if (!Number.isFinite(score)) {
+    return 'Awaiting telemetry';
+  }
+  if (score >= 72) {
+    return 'Nominal signal window';
+  }
+  if (score >= 45) {
+    return 'Degraded signal window';
+  }
+  return 'Critical signal window';
+}
+
+function receiptSignalScore(receipt) {
+  const components = [];
+  if (Number.isFinite(receipt?.rssi)) {
+    components.push(clamp(((Number(receipt.rssi) + 120) / 75) * 100, 0, 100));
+  }
+  if (Number.isFinite(receipt?.snr)) {
+    components.push(clamp(((Number(receipt.snr) + 20) / 40) * 100, 0, 100));
+  }
+  if (components.length === 0) {
+    return null;
+  }
+  return Math.round(components.reduce((sum, value) => sum + value, 0) / components.length);
+}
+
+function transportSummary(snapshot) {
+  const activeCount = Number(snapshot?.observerStats?.activeCount || 0);
+  const windowSeconds = Number(snapshot?.observerStats?.windowSeconds || 0);
+  const directory = Array.isArray(snapshot?.observerDirectory) ? snapshot.observerDirectory : [];
+  const configuredCount = Math.max(directory.length, Number(snapshot?.observerStats?.configuredCount || 0));
+  const maxPacketCount = Math.max(
+    1,
+    ...directory.map((observer) => Number(observer?.packetCount || 0)),
+  );
+  const activityBars = directory.slice(0, 8).map((observer) => {
+    const packetCount = Number(observer?.packetCount || 0);
+    return clamp((packetCount / maxPacketCount) * 100, 10, 100);
+  });
+  const stateLabel = snapshot?.mqtt?.connected ? 'Live' : (isSharePage() ? 'Shared' : 'Offline');
+  return {
+    stateLabel,
+    tone: directory.length > 0
+      ? (snapshot?.mqtt?.connected ? 'good' : (isSharePage() ? 'warning' : 'warning'))
+      : 'neutral',
+    activityBars,
+    density: `${activeCount} / ${configuredCount || 0}`,
+    summary: directory.length > 0
+      ? `${activeCount} active nodes · ${formatWindow(windowSeconds)}`
+      : 'Awaiting observer directory.',
+    detail: directory.length > 0
+      ? `${directory.length} known observer${directory.length === 1 ? '' : 's'} on file.`
+      : 'No observer telemetry yet.',
+  };
+}
+
+function signalSummary(session) {
+  const receipts = Array.isArray(session?.receipts) ? [...session.receipts] : [];
+  const points = receipts
+    .map((receipt) => receiptSignalScore(receipt))
+    .filter((value) => Number.isFinite(value));
+  if (points.length === 0) {
+    return {
+      value: '--',
+      label: 'Awaiting telemetry.',
+      tone: 'neutral',
+      points: [],
+    };
+  }
+  const average = Math.round(points.reduce((sum, value) => sum + value, 0) / points.length);
+  return {
+    value: `${average}%`,
+    label: scoreLabel(average),
+    tone: scoreTone(average),
+    points,
+  };
+}
+
+function latencySummary(session) {
+  const receipts = Array.isArray(session?.receipts)
+    ? [...session.receipts]
+        .filter((receipt) => receipt?.firstSeenAt)
+        .sort((left, right) => left.firstSeenAt - right.firstSeenAt)
+    : [];
+  if (receipts.length === 0) {
+    return {
+      value: '--',
+      label: 'Awaiting receipt spread.',
+      tone: 'neutral',
+      points: [],
+    };
+  }
+  const firstSeenAt = receipts[0].firstSeenAt;
+  const lastSeenAt = receipts[receipts.length - 1].firstSeenAt;
+  const spread = Math.max(0, lastSeenAt - firstSeenAt);
+  const points = receipts.map((receipt) => {
+    if (spread <= 0) {
+      return 100;
+    }
+    return clamp(((receipt.firstSeenAt - firstSeenAt) / spread) * 100, 10, 100);
+  });
+  return {
+    value: spread > 0 ? `+${formatElapsed(spread)}` : '0 ms',
+    label: spread > 0
+      ? `${receipts.length} observers across ${formatElapsed(spread)}`
+      : `${receipts.length} observer${receipts.length === 1 ? '' : 's'} at the same moment`,
+    tone: spread > 45000 ? 'critical' : spread > 12000 ? 'warning' : 'good',
+    points,
+  };
+}
+
+function renderGlanceMetrics(session) {
+  const snapshot = state.snapshot;
+  if (!snapshot) {
+    return;
+  }
+
+  const transport = transportSummary(snapshot);
+  const signal = signalSummary(session);
+  const latency = latencySummary(session);
+
+  if (ui.networkWindow) {
+    ui.networkWindow.textContent = transport.summary;
+  }
+  if (ui.networkState) {
+    ui.networkState.textContent = transport.stateLabel;
+  }
+  if (ui.observerDensity) {
+    ui.observerDensity.textContent = transport.density;
+  }
+  if (ui.observerDensityLabel) {
+    ui.observerDensityLabel.textContent = transport.summary;
+  }
+  if (ui.observerDensityDetail) {
+    ui.observerDensityDetail.textContent = transport.detail;
+  }
+  if (ui.signalQuality) {
+    ui.signalQuality.textContent = signal.value;
+  }
+  if (ui.signalQualityLabel) {
+    ui.signalQualityLabel.textContent = signal.label;
+  }
+  if (ui.latencyScore) {
+    ui.latencyScore.textContent = latency.value;
+  }
+  if (ui.latencyLabel) {
+    ui.latencyLabel.textContent = latency.label;
+  }
+
+  renderSparkline(ui.observerSparkline, transport.activityBars, transport.tone);
+  renderSparkline(ui.observerLoadSparkline, transport.activityBars.slice().reverse(), transport.tone);
+  renderSparkline(ui.signalSparkline, signal.points, signal.tone);
+  renderSparkline(ui.latencySparkline, latency.points, latency.tone);
+}
+
 function retentionNote() {
   const seconds = Number(state.snapshot?.results?.retentionSeconds || 0);
   if (!seconds) {
@@ -625,10 +881,10 @@ function renderExpectedObservers(session) {
     item.className = `observer-pill ${observer.seen ? 'seen' : 'waiting'}`;
     item.innerHTML = `
       <div class="observer-main">
-        <strong class="observer-label">${observer.label}</strong>
-        <div class="small-note observer-hash">${observer.hash || ''}</div>
+        <strong class="observer-label">${escapeHtml(observer.label)}</strong>
+        <div class="small-note observer-hash">${escapeHtml(observer.hash || '')}</div>
       </div>
-      <span class="status">${observer.seen ? 'Seen' : 'Waiting'}</span>
+      <span class="status">${observer.seen ? 'Seen' : 'Standby'}</span>
     `;
     ui.expectedObservers.appendChild(item);
   }
@@ -660,11 +916,13 @@ function renderObserverAllowlist() {
       : observer.isRetained === false
         ? 'not recently heard'
         : 'idle';
+    const locationLabel = observer.hasLocation ? 'mapped' : 'no map';
     item.innerHTML = `
       <input type="checkbox" value="${observer.key}" ${selected.has(observer.key) ? 'checked' : ''}>
       <span class="observer-option-copy">
-        <strong>${observer.label}</strong>
-        <span>${observer.hash || '--'} · ${observer.shortKey} · ${status}</span>
+        <strong>${escapeHtml(observer.label)}</strong>
+        <span>${escapeHtml(observer.hash || '--')} · ${escapeHtml(observer.shortKey)} · ${escapeHtml(status)}</span>
+        <span>${observer.packetCount || 0} packet${observer.packetCount === 1 ? '' : 's'} · ${locationLabel}</span>
       </span>
     `;
     const checkbox = item.querySelector('input');
@@ -728,9 +986,20 @@ function applySiteBranding(snapshot) {
 
 function mapKnownObservers(session) {
   const directory = observerDirectory();
-  let source = directory;
+  const mergedDirectory = new Map();
+  for (const observer of configuredDefaultObservers()) {
+    mergedDirectory.set(observer.key, observer);
+  }
+  for (const observer of directory) {
+    const existing = mergedDirectory.get(observer.key) || {};
+    mergedDirectory.set(observer.key, {
+      ...existing,
+      ...observer,
+    });
+  }
+  let source = [...mergedDirectory.values()];
   if (mapObserverScope === 'expected') {
-    const directoryByKey = new Map(directory.map((observer) => [observer.key, observer]));
+    const directoryByKey = new Map(source.map((observer) => [observer.key, observer]));
     const expected = Array.isArray(session?.expectedObservers)
       ? session.expectedObservers.filter((observer) => observer?.key)
       : [];
@@ -766,6 +1035,7 @@ function ensureObserverMap() {
     zoomControl: true,
     attributionControl: true,
   });
+  state.map.instance.setView([20, 0], 2);
   return state.map.instance;
 }
 
@@ -773,7 +1043,7 @@ function currentTileLayer() {
   if (!window.L) {
     return null;
   }
-  if (state.mapTheme === 'light') {
+  if (state.uiTheme === 'light') {
     return window.L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
       maxZoom: 19,
       attribution: '&copy; OpenStreetMap contributors',
@@ -799,24 +1069,22 @@ function renderObserverMap(session) {
   const locatedObservers = mapKnownObservers(session);
   const mapInstance = ensureObserverMap();
 
-  ui.mapThemeToggle.textContent = state.mapTheme === 'dark' ? 'Light Map' : 'Dark Map';
   ui.mapObserverNote.textContent = locatedObservers.length > 0
     ? `${locatedObservers.filter((observer) => observer.seen).length}/${locatedObservers.length} mapped observers reached.`
-    : 'Waiting for observer coordinates.';
+    : 'No observer coordinates yet. The map stays live and will populate as coordinates arrive.';
   ui.mapEmpty.classList.toggle('hidden', locatedObservers.length > 0);
-  ui.observerMap.classList.toggle('hidden', locatedObservers.length === 0);
 
   if (!mapInstance || !window.L) {
     return;
   }
 
-  if (!state.map.layer || state.map.layerTheme !== state.mapTheme) {
+  if (!state.map.layer || state.map.layerTheme !== state.uiTheme) {
     const nextLayer = currentTileLayer();
     if (state.map.layer) {
       mapInstance.removeLayer(state.map.layer);
     }
     state.map.layer = nextLayer;
-    state.map.layerTheme = state.mapTheme;
+    state.map.layerTheme = state.uiTheme;
     if (nextLayer) {
       nextLayer.addTo(mapInstance);
     }
@@ -853,6 +1121,9 @@ function renderObserverMap(session) {
   if (bounds.length > 0 && boundsKey !== state.map.boundsKey) {
     mapInstance.fitBounds(bounds, { padding: [26, 26], maxZoom: 10 });
     state.map.boundsKey = boundsKey;
+  } else if (bounds.length === 0 && state.map.boundsKey !== '__empty__') {
+    mapInstance.setView([20, 0], 2);
+    state.map.boundsKey = '__empty__';
   }
   window.setTimeout(() => {
     mapInstance.invalidateSize();
@@ -867,6 +1138,12 @@ function renderReceipts(session) {
   for (const receipt of receipts) {
     const card = document.createElement('article');
     card.className = 'receipt-card';
+    card.dataset.observerKey = receipt.observerKey;
+    const signal = receiptSignalScore(receipt);
+    const signalTone = scoreTone(signal);
+    const pathMarkup = receipt.path.length > 0
+      ? receipt.path.map((hop) => `<span>${escapeHtml(hop)}</span>`).join('')
+      : '<span>No path data</span>';
     const metrics = [
       receipt.rssi != null ? `RSSI ${receipt.rssi}` : '',
       receipt.snr != null ? `SNR ${receipt.snr}` : '',
@@ -878,15 +1155,31 @@ function renderReceipts(session) {
     card.innerHTML = `
       <div class="receipt-head">
         <div>
-          <h3 class="receipt-title">${receipt.observerLabel}</h3>
-          <div class="receipt-hash">${receipt.observerHash || ''} · ${receipt.observerShortKey}</div>
+          <h3 class="receipt-title">${escapeHtml(receipt.observerLabel)}</h3>
+          <div class="receipt-hash">${escapeHtml(receipt.observerHash || '')} · ${escapeHtml(receipt.observerShortKey)}</div>
         </div>
         <div class="small-note">${formatTime(receipt.firstSeenAt)}</div>
       </div>
       <p class="receipt-meta">
         Seen ${receipt.count} time${receipt.count === 1 ? '' : 's'}${metrics ? ` · ${metrics}` : ''}
       </p>
-      <div class="receipt-path">${receipt.path.length > 0 ? receipt.path.join(' → ') : 'No path data'}</div>
+      <div class="receipt-meter-grid">
+        <div class="receipt-meter">
+          <span>Signal</span>
+          <div class="meter-track ${signalTone}">
+            <span style="width: ${Number.isFinite(signal) ? signal : 12}%;"></span>
+          </div>
+          <strong>${Number.isFinite(signal) ? `${signal}%` : '--'}</strong>
+        </div>
+        <div class="receipt-meter">
+          <span>Latency</span>
+          <div class="meter-track ${receipt.duration != null && receipt.duration > 1500 ? 'warning' : 'good'}">
+            <span style="width: ${receipt.duration != null ? clamp((Number(receipt.duration) / 3000) * 100, 12, 100) : 20}%;"></span>
+          </div>
+          <strong>${receipt.duration != null ? `${receipt.duration} ms` : 'n/a'}</strong>
+        </div>
+      </div>
+      <div class="receipt-path">${pathMarkup}</div>
     `;
     ui.receipts.appendChild(card);
   }
@@ -949,10 +1242,11 @@ function renderHistory(sessions) {
   for (const session of sessions) {
     const item = document.createElement('article');
     item.className = 'history-item';
+    item.dataset.sessionId = session.id;
     item.innerHTML = `
       <div>
-        <div class="history-code">${session.code}</div>
-        <p>${session.observedCount}/${session.expectedCount} observers · ${session.healthLabel}</p>
+        <div class="history-code">${escapeHtml(session.code)}</div>
+        <p>${session.observedCount}/${session.expectedCount} observers · ${escapeHtml(session.healthLabel)}</p>
       </div>
       <div>
         <strong class="${healthClass(session.healthLabel)}">${session.healthPercent}%</strong>
@@ -963,11 +1257,289 @@ function renderHistory(sessions) {
   }
 }
 
+function drawerStat(label, value) {
+  return `
+    <div class="drawer-stat">
+      <span class="meta-label">${escapeHtml(label)}</span>
+      <strong>${escapeHtml(value)}</strong>
+    </div>
+  `;
+}
+
+function drawerListItem(title, detail, meta = '') {
+  return `
+    <div class="drawer-list__item">
+      <strong>${escapeHtml(title)}</strong>
+      <p>${escapeHtml(detail)}</p>
+      ${meta ? `<div class="small-note">${escapeHtml(meta)}</div>` : ''}
+    </div>
+  `;
+}
+
+function buildDrawerContent() {
+  const snapshot = state.snapshot;
+  const session = currentSession();
+  const directory = selectableObservers();
+  const mappedObservers = mapKnownObservers(session);
+  const receipts = Array.isArray(session?.receipts) ? session.receipts : [];
+  const historySessions = state.trackedSessionIds
+    .map((id) => state.sessions.get(id))
+    .filter(Boolean);
+  const transport = snapshot ? transportSummary(snapshot) : null;
+  const signal = signalSummary(session);
+  const latency = latencySummary(session);
+
+  switch (state.drawer.kind) {
+    case 'session':
+      return {
+        meta: 'Command Sequence',
+        title: session ? `Session ${session.code}` : 'Session Control',
+        body: `
+          <section class="drawer-card">
+            <h3>Session Summary</h3>
+            <div class="drawer-stat-grid">
+              ${drawerStat('Status', session?.status?.toUpperCase() || 'IDLE')}
+              ${drawerStat('Share Window', session ? formatDateTime(session.resultExpiresAt) : retentionNote())}
+              ${drawerStat('Uses Remaining', session ? String(session.usesRemaining) : '--')}
+              ${drawerStat('Hash', session?.messageHash || 'Pending')}
+            </div>
+          </section>
+          <section class="drawer-card">
+            <h3>Operator Instructions</h3>
+            <pre class="drawer-codeblock">${escapeHtml(session?.instructions || 'Create a session to start listening.')}</pre>
+          </section>
+          <section class="drawer-card">
+            <h3>Matched Message</h3>
+            <pre class="drawer-codeblock">${escapeHtml(session?.messageBody || 'Waiting for an incoming message on the configured test channel.')}</pre>
+          </section>
+        `,
+      };
+    case 'transport':
+      return {
+        meta: 'Transport Matrix',
+        title: 'Network Transport',
+        body: `
+          <section class="drawer-card">
+            <h3>Live Transport</h3>
+            <div class="drawer-stat-grid">
+              ${drawerStat('State', transport?.stateLabel || 'Offline')}
+              ${drawerStat('Broker', snapshot?.mqtt?.broker || 'Unknown')}
+              ${drawerStat('Channel', snapshot?.testChannel?.name ? `#${snapshot.testChannel.name}` : 'Unknown')}
+              ${drawerStat('Topics', Array.isArray(snapshot?.mqtt?.topics) ? String(snapshot.mqtt.topics.length) : '0')}
+            </div>
+          </section>
+          <section class="drawer-card">
+            <h3>Observer Window</h3>
+            <div class="drawer-list">
+              ${drawerListItem(
+                'Retention Window',
+                transport?.summary || 'Awaiting observer directory.',
+                transport?.detail || '',
+              )}
+            </div>
+          </section>
+        `,
+      };
+    case 'observers':
+      return {
+        meta: 'Target Matrix',
+        title: 'Observer Targeting',
+        body: directory.length > 0
+          ? `
+            <section class="drawer-card">
+              <h3>Target Summary</h3>
+              <div class="drawer-stat-grid">
+                ${drawerStat('Default Source', snapshot?.defaultObserverSource || 'Unknown')}
+                ${drawerStat('Directory Size', String(directory.length))}
+                ${drawerStat('Selected Mode', usingDefaultObserverSet() ? 'Default set' : 'Custom set')}
+                ${drawerStat('Active Nodes', String(snapshot?.observerStats?.activeCount || 0))}
+              </div>
+            </section>
+            <section class="drawer-card">
+              <h3>Node Inventory</h3>
+              <div class="drawer-list">
+                ${directory.map((observer) => drawerListItem(
+                  observer.label,
+                  `${observer.hash || '--'} · ${observer.shortKey}`,
+                  `${observer.packetCount || 0} packet${observer.packetCount === 1 ? '' : 's'} · ${observer.hasLocation ? 'mapped' : 'no coordinates'} · ${observer.isActive ? 'active' : 'idle'}`,
+                )).join('')}
+              </div>
+            </section>
+          `
+          : `
+            <section class="drawer-card">
+              <h3>Observer Targeting</h3>
+              <p>No observers available yet. Node inventory appears as metadata and packets arrive.</p>
+            </section>
+          `,
+      };
+    case 'map':
+      return {
+        meta: 'Geo View',
+        title: 'Coverage Map',
+        body: mappedObservers.length > 0
+          ? `
+            <section class="drawer-card">
+              <h3>Mapped Observers</h3>
+              <div class="drawer-stat-grid">
+                ${drawerStat('Mapped', String(mappedObservers.length))}
+                ${drawerStat('Reached', String(mappedObservers.filter((observer) => observer.seen).length))}
+                ${drawerStat('Theme', state.uiTheme === 'dark' ? 'Dark mode' : 'Light mode')}
+                ${drawerStat('Scope', mapObserverScope === 'expected' ? 'Expected' : 'Directory')}
+              </div>
+            </section>
+            <section class="drawer-card">
+              <h3>Coordinates</h3>
+              <div class="drawer-list">
+                ${mappedObservers.map((observer) => drawerListItem(
+                  observer.label,
+                  `${observer.lat}, ${observer.lon}`,
+                  `${observer.seen ? 'Seen by this check' : 'Not seen by this check'} · ${observer.hash || '--'}`,
+                )).join('')}
+              </div>
+            </section>
+          `
+          : `
+            <section class="drawer-card">
+              <h3>Coverage Map</h3>
+              <p>Waiting for observer coordinates.</p>
+            </section>
+          `,
+      };
+    case 'reports':
+      return {
+        meta: 'Signal Trace',
+        title: 'Technical Logs',
+        body: receipts.length > 0
+          ? `
+            <section class="drawer-card">
+              <h3>Receipt Summary</h3>
+              <div class="drawer-stat-grid">
+                ${drawerStat('Signal Quality', signal.value)}
+                ${drawerStat('Spread', latency.value)}
+                ${drawerStat('Observer Reports', String(receipts.length))}
+                ${drawerStat('Sender', session?.sender || 'Pending')}
+              </div>
+            </section>
+            <section class="drawer-card">
+              <h3>Trace Lines</h3>
+              <div class="console-lines">
+                ${receipts.map((receipt) => `
+                  <div class="console-line">
+                    <strong>${escapeHtml(receipt.observerLabel)}</strong>
+                    <span>${escapeHtml(formatTime(receipt.firstSeenAt))} · ${escapeHtml(receipt.topic || 'meshcore packet')}</span>
+                    <code>${escapeHtml(receipt.messageHash || 'no-hash')}</code>
+                    <span>${escapeHtml((receipt.path || []).join(' -> ') || 'No path data')}</span>
+                  </div>
+                `).join('')}
+              </div>
+            </section>
+          `
+          : `
+            <section class="drawer-card">
+              <h3>Technical Logs</h3>
+              <p>Timeline appears after the first observer report.</p>
+            </section>
+          `,
+      };
+    case 'history':
+      return {
+        meta: 'Session Archive',
+        title: 'Recent Sessions',
+        body: historySessions.length > 0
+          ? `
+            <section class="drawer-card">
+              <h3>Browser Session History</h3>
+              <div class="drawer-list">
+                ${historySessions.map((entry) => drawerListItem(
+                  entry.code,
+                  `${entry.observedCount}/${entry.expectedCount} observers · ${entry.healthPercent}%`,
+                  `${entry.healthLabel} · ${formatTime(entry.createdAt)}`,
+                )).join('')}
+              </div>
+            </section>
+          `
+          : `
+            <section class="drawer-card">
+              <h3>Recent Sessions</h3>
+              <p>No previous checks in this browser session.</p>
+            </section>
+          `,
+      };
+    case 'receipt': {
+      const receipt = receipts.find((entry) => entry.observerKey === state.drawer.key);
+      if (!receipt) {
+        return null;
+      }
+      return {
+        meta: 'Packet Detail',
+        title: receipt.observerLabel,
+        body: `
+          <section class="drawer-card">
+            <h3>Receipt Metrics</h3>
+            <div class="drawer-stat-grid">
+              ${drawerStat('First Seen', formatTime(receipt.firstSeenAt))}
+              ${drawerStat('Message Hash', receipt.messageHash || 'Pending')}
+              ${drawerStat('RSSI', receipt.rssi != null ? String(receipt.rssi) : 'n/a')}
+              ${drawerStat('SNR', receipt.snr != null ? String(receipt.snr) : 'n/a')}
+              ${drawerStat('Duration', receipt.duration != null ? `${receipt.duration} ms` : 'n/a')}
+              ${drawerStat('Packets', String(receipt.count))}
+            </div>
+          </section>
+          <section class="drawer-card">
+            <h3>Path Trace</h3>
+            <pre class="drawer-codeblock">${escapeHtml((receipt.path || []).join(' -> ') || 'No path data')}</pre>
+          </section>
+        `,
+      };
+    }
+    default:
+      return null;
+  }
+}
+
+function renderDrawer() {
+  if (!ui.detailDrawer || !ui.drawerBody || !ui.drawerMeta || !ui.drawerTitle) {
+    return;
+  }
+  if (!state.drawer.kind) {
+    ui.detailDrawer.setAttribute('aria-hidden', 'true');
+    document.body.classList.remove('drawer-open');
+    return;
+  }
+  const content = buildDrawerContent();
+  if (!content) {
+    state.drawer.kind = '';
+    state.drawer.key = '';
+    ui.detailDrawer.setAttribute('aria-hidden', 'true');
+    document.body.classList.remove('drawer-open');
+    return;
+  }
+  ui.drawerMeta.textContent = content.meta;
+  ui.drawerTitle.textContent = content.title;
+  ui.drawerBody.innerHTML = content.body;
+  ui.detailDrawer.setAttribute('aria-hidden', 'false');
+  document.body.classList.add('drawer-open');
+}
+
+function openDrawer(kind, key = '') {
+  state.drawer.kind = kind;
+  state.drawer.key = key;
+  renderDrawer();
+}
+
+function closeDrawer() {
+  state.drawer.kind = '';
+  state.drawer.key = '';
+  renderDrawer();
+}
+
 function render() {
   const snapshot = state.snapshot;
   if (!snapshot) {
     return;
   }
+  applyUiTheme();
 
   const channelLabel = `#${snapshot.testChannel.name}`;
   const historySessions = state.trackedSessionIds
@@ -1015,7 +1587,9 @@ function render() {
     renderReceiptTimeline(null);
     renderReceipts(null);
     renderHistory(historySessions);
+    renderGlanceMetrics(null);
     updateRing(0, 'Waiting');
+    renderDrawer();
     return;
   }
 
@@ -1049,6 +1623,8 @@ function render() {
   renderReceiptTimeline(session);
   renderReceipts(session);
   renderHistory(historySessions);
+  renderGlanceMetrics(session);
+  renderDrawer();
 }
 
 function applySnapshot(snapshot) {
@@ -1206,10 +1782,69 @@ ui.observerAllowlistClear.addEventListener('click', () => {
   scheduleSessionRetarget();
 });
 
-ui.mapThemeToggle.addEventListener('click', () => {
-  state.mapTheme = state.mapTheme === 'dark' ? 'light' : 'dark';
-  saveMapTheme();
-  render();
+if (ui.uiThemeToggle) {
+  ui.uiThemeToggle.addEventListener('click', () => {
+    state.uiTheme = state.uiTheme === 'dark' ? 'light' : 'dark';
+    saveUiTheme();
+    if (ui.actionMenu) {
+      ui.actionMenu.open = false;
+    }
+    render();
+  });
+}
+
+if (ui.drawerClose) {
+  ui.drawerClose.addEventListener('click', () => {
+    closeDrawer();
+  });
+}
+
+if (ui.drawerScrim) {
+  ui.drawerScrim.addEventListener('click', () => {
+    closeDrawer();
+  });
+}
+
+function targetIsPanelInteractive(target) {
+  return Boolean(target.closest(
+    'button, a, input, label, .leaflet-container, .leaflet-control-container, .leaflet-popup, .leaflet-marker-pane, .detail-drawer',
+  ));
+}
+
+document.addEventListener('click', (event) => {
+  if (!(event.target instanceof Element)) {
+    return;
+  }
+  if (ui.actionMenu?.open && !event.target.closest('#action-menu')) {
+    ui.actionMenu.open = false;
+  }
+  const action = event.target.closest('[data-drawer-action]');
+  if (action) {
+    event.preventDefault();
+    openDrawer(action.dataset.drawerAction || '');
+    return;
+  }
+
+  const receiptCard = event.target.closest('.receipt-card[data-observer-key]');
+  if (receiptCard && ui.receipts?.contains(receiptCard) && !targetIsPanelInteractive(event.target)) {
+    openDrawer('receipt', receiptCard.dataset.observerKey || '');
+    return;
+  }
+
+  const panel = event.target.closest('[data-drawer-panel]');
+  if (panel && !targetIsPanelInteractive(event.target)) {
+    openDrawer(panel.dataset.drawerPanel || '');
+  }
+});
+
+window.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape' && ui.actionMenu?.open) {
+    ui.actionMenu.open = false;
+    return;
+  }
+  if (event.key === 'Escape' && state.drawer.kind) {
+    closeDrawer();
+  }
 });
 
 bootstrap();

--- a/public/index.html
+++ b/public/index.html
@@ -19,197 +19,364 @@
     <link rel="icon" type="image/png" href="/logo.png">
     <link rel="apple-touch-icon" href="/logo.png">
     <link rel="manifest" href="/manifest.webmanifest">
-    <meta name="theme-color" content="#101512">
+    <meta name="theme-color" content="#07111d">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <link rel="stylesheet" href="/vendor/leaflet/leaflet.css">
     <link rel="stylesheet" href="/styles.css">
   </head>
-  <body>
-    <main class="shell">
-      <section class="hero">
-        <div class="hero-copy">
-          <p class="eyebrow" id="hero-eyebrow">MeshCore Observer Coverage</p>
-          <h1 id="hero-title">Check your mesh reach.</h1>
-          <p class="lede">
-            <span id="hero-description-prefix">Generate a test code, send it to</span>
-            <strong id="hero-channel">#health-check</strong>
-            <span id="hero-description-suffix">and watch the observers that receive the message report back in real time.</span>
-          </p>
+  <body class="noc-body" data-page-mode="app" data-ui-theme="dark">
+    <div class="screen-glow" aria-hidden="true"></div>
+    <main class="noc-shell">
+      <section class="workspace">
+        <div class="splash-scene" aria-hidden="true">
+          <span class="splash-scene__mesh"></span>
+          <span class="splash-scene__beam"></span>
+          <span class="splash-scene__grid"></span>
+          <span class="splash-scene__ring splash-scene__ring--left"></span>
+          <span class="splash-scene__ring splash-scene__ring--right"></span>
+          <span class="splash-scene__badge splash-scene__badge--one">Adaptive mesh</span>
+          <span class="splash-scene__badge splash-scene__badge--two">Map + trace</span>
         </div>
-        <div class="hero-card" id="session-card">
-          <div class="hero-topline">
-            <span class="pill" id="mqtt-pill">MQTT offline</span>
-            <div class="hero-actions">
-              <button class="ghost-button hidden" id="install-app-button" type="button">
-                Install App
-              </button>
-              <a class="ghost-button hidden" href="#" id="external-link" rel="noopener noreferrer" target="_blank">External Link</a>
-              <button class="ghost-button" id="new-session-button" type="button">
-                New Code
-              </button>
+        <section class="hero-stage">
+          <article class="hero-panel hero-stage__lead">
+            <div class="dock-brand">
+              <div class="brand-orb" aria-hidden="true">
+                <span></span>
+              </div>
+              <div class="brand-copy">
+                <p class="eyebrow" id="hero-eyebrow">MeshCore Observer Coverage</p>
+                <h1 id="hero-title">Check your mesh reach.</h1>
+              </div>
             </div>
-          </div>
-          <div class="session-code-row">
-            <div class="session-code" id="session-code">...</div>
-            <div class="session-code-actions">
-              <button class="ghost-button copy-button" id="copy-session-code" type="button">
-                Copy
-              </button>
-              <button class="ghost-button copy-button" id="share-session" type="button">
-                Share
-              </button>
-            </div>
-          </div>
-          <p class="session-instructions" id="session-instructions">
-            Loading session…
-          </p>
-          <p class="small-note session-share-note" id="session-share-note">
-            Shared links are kept for one week by default.
-          </p>
-          <div class="session-meta">
-            <div>
-              <span class="meta-label">Status</span>
-              <strong id="session-status">Waiting</strong>
-            </div>
-            <div>
-              <span class="meta-label">Message Hash</span>
-              <strong><a class="hash-link pending" id="session-hash" href="#" rel="noopener noreferrer" target="_blank">Pending</a></strong>
-            </div>
-          </div>
-        </div>
-      </section>
 
-      <section class="dashboard">
-        <article class="panel score-panel">
-          <div class="panel-header">
-            <div>
-              <p class="panel-label">Current Health</p>
-              <h2 id="health-label">Waiting</h2>
-            </div>
-            <div class="score-ring">
-              <svg class="score-ring__svg" viewBox="0 0 120 120" aria-hidden="true">
-                <circle class="score-ring__track" cx="60" cy="60" r="50"/>
-                <circle class="score-ring__fill" cx="60" cy="60" r="50"/>
-              </svg>
-              <span id="health-percent"><span class="score-num">0</span><span class="score-unit">%</span></span>
-            </div>
-          </div>
-          <div class="score-grid">
-            <div class="metric-card">
-              <span class="metric-label">Observers Reached</span>
-              <strong id="observed-count">0 / 0</strong>
-            </div>
-            <div class="metric-card">
-              <span class="metric-label">Sender</span>
-              <strong id="sender-name">Pending</strong>
-            </div>
-            <div class="metric-card">
-              <span class="metric-label">Channel</span>
-              <strong id="channel-name">#health-check</strong>
-            </div>
-            <div class="metric-card">
-              <span class="metric-label">Broker</span>
-              <strong id="broker-name">Loading</strong>
-            </div>
-          </div>
-          <div class="message-preview">
-            <span class="meta-label">Matched Message</span>
-            <p id="message-preview">Waiting for your #health-check message.</p>
-          </div>
-        </article>
+            <p class="dock-lede lede">
+              <span id="hero-description-prefix">Generate a test code, send it to</span>
+              <strong id="hero-channel">#health-check</strong>
+              <span id="hero-description-suffix">and watch the observers that receive the message report back in real time.</span>
+            </p>
 
-        <article class="panel">
-          <div class="panel-header slim">
-            <div>
-              <p class="panel-label">Observer Set</p>
-              <h2>Observers</h2>
+            <div class="hero-stage__pulse">
+              <span class="hero-stage__pulse-dot" aria-hidden="true"></span>
+              <div>
+                <p class="panel-label">Live Surface</p>
+                <p class="small-note">An always-on scan view with oversized signal cues and a single continuous command story.</p>
+              </div>
             </div>
-            <button class="ghost-button" id="observer-allowlist-clear" type="button">
-              Default Set
+
+            <nav class="dock-nav" aria-label="Dashboard sections">
+              <a class="dock-nav__item" href="#command-center">
+                <span>N0</span>
+                <strong>Control</strong>
+              </a>
+              <a class="dock-nav__item" href="#health-at-a-glance">
+                <span>N1</span>
+                <strong>Glance</strong>
+              </a>
+              <a class="dock-nav__item" href="#coverage-map">
+                <span>N2</span>
+                <strong>Map</strong>
+              </a>
+              <a class="dock-nav__item" href="#observer-reports">
+                <span>N3</span>
+                <strong>Logs</strong>
+              </a>
+            </nav>
+          </article>
+
+          <article class="hero-panel hero-stage__brief">
+            <div class="toolbar-copy">
+              <p class="toolbar-label">Control Center</p>
+              <div>
+                <h2>Health at a glance</h2>
+                <p>Track the active code, monitor the live transport state, and pivot into map or trace detail without leaving the main stage.</p>
+              </div>
+            </div>
+
+            <div class="dock-status-stack">
+              <span class="pill status-pill" id="mqtt-pill">MQTT offline</span>
+              <div class="dock-note">
+                <span class="meta-label">Observer Window</span>
+                <strong id="network-window">Awaiting bootstrap</strong>
+              </div>
+            </div>
+
+            <div class="dock-meta hero-stage__meta-strip">
+              <div class="dock-meta__item">
+                <span class="meta-label">Console</span>
+                <strong>Secondary Monitor Ready</strong>
+              </div>
+              <div class="dock-meta__item">
+                <span class="meta-label">Mode</span>
+                <strong id="mode-label">Dark Command Surface</strong>
+              </div>
+            </div>
+          </article>
+
+          <div class="hero-actions-stack hero-stage__action-rail">
+            <details class="action-menu" id="action-menu">
+              <summary class="control-button ghost-button action-menu__button">Menu</summary>
+              <div class="action-menu__panel">
+                <button class="control-button ghost-button action-menu__item" id="ui-theme-toggle" type="button">
+                  Light Mode
+                </button>
+                <button class="control-button ghost-button action-menu__item hidden" id="install-app-button" type="button">
+                  Install App
+                </button>
+                <a class="control-button ghost-button action-menu__item hidden" href="#" id="external-link" rel="noopener noreferrer" target="_blank">External Link</a>
+              </div>
+            </details>
+            <button class="control-button primary-button" id="new-session-button" type="button">
+              New Code
             </button>
           </div>
-          <p class="small-note allowlist-note" id="observer-allowlist-note">
-            Default: 0 observers.
-          </p>
-          <div class="observer-selector" id="observer-allowlist"></div>
-          <div class="panel-divider"></div>
-          <div class="panel-header slim">
-            <div>
-              <p class="panel-label">Target</p>
-              <h2>Score Against</h2>
-            </div>
-            <p class="small-note" id="expected-source">Default</p>
-          </div>
-          <div class="observer-badges" id="expected-observers"></div>
-        </article>
 
-        <article class="panel wide">
-          <div class="panel-header slim">
-            <div>
-              <p class="panel-label">Coverage Map</p>
-              <h2>Where the observers are</h2>
+          <section class="glance-grid telemetry-strip" id="health-at-a-glance">
+            <article class="glance-card telemetry-strip__item" data-drawer-panel="transport">
+            <div class="glance-card__head">
+              <span class="panel-label">Transport</span>
+              <button class="panel-lens" data-drawer-action="transport" type="button">Inspect</button>
             </div>
-            <button class="ghost-button" id="map-theme-toggle" type="button">
-              Light Map
-            </button>
-          </div>
-          <p class="small-note" id="map-observer-note">Waiting for observer coordinates.</p>
-          <div class="empty-state compact hidden" id="map-empty">
-            No saved observer coordinates yet. The app will learn them from MQTT metadata and store them in <code>observer.json</code>.
-          </div>
-          <div class="observer-map" id="observer-map"></div>
-        </article>
+            <strong class="glance-card__value" id="network-state">Offline</strong>
+            <div class="sparkline" id="observer-sparkline" aria-hidden="true"></div>
+            <p class="small-note" id="observer-density-label">Awaiting observer directory.</p>
+            </article>
 
-        <article class="panel wide">
-          <div class="panel-header slim">
-            <div>
-              <p class="panel-label">Observer Reports</p>
-              <h2>Who saw the message</h2>
+            <article class="glance-card telemetry-strip__item" data-drawer-panel="observers">
+            <div class="glance-card__head">
+              <span class="panel-label">Node Count</span>
+              <button class="panel-lens" data-drawer-action="observers" type="button">Inspect</button>
             </div>
-            <p class="small-note" id="active-observer-note">0 active observers</p>
-          </div>
-          <div class="timeline-block">
+            <strong class="glance-card__value" id="observer-density">0 / 0</strong>
+            <div class="sparkline" id="observer-load-sparkline" aria-hidden="true"></div>
+            <p class="small-note" id="observer-density-detail">No observer telemetry yet.</p>
+            </article>
+
+            <article class="glance-card telemetry-strip__item" data-drawer-panel="health">
+            <div class="glance-card__head">
+              <span class="panel-label">Signal Quality</span>
+              <button class="panel-lens" data-drawer-action="health" type="button">Inspect</button>
+            </div>
+            <strong class="glance-card__value" id="signal-quality">--</strong>
+            <div class="sparkline" id="signal-sparkline" aria-hidden="true"></div>
+            <p class="small-note" id="signal-quality-label">Awaiting telemetry.</p>
+            </article>
+
+            <article class="glance-card telemetry-strip__item" data-drawer-panel="reports">
+            <div class="glance-card__head">
+              <span class="panel-label">Receipt Spread</span>
+              <button class="panel-lens" data-drawer-action="reports" type="button">Inspect</button>
+            </div>
+            <strong class="glance-card__value" id="latency-score">--</strong>
+            <div class="sparkline" id="latency-sparkline" aria-hidden="true"></div>
+            <p class="small-note" id="latency-label">Awaiting receipt spread.</p>
+            </article>
+          </section>
+        </section>
+
+        <section class="command-grid">
+          <article class="panel command-panel marquee-panel" data-drawer-panel="session" id="command-center">
+            <div class="panel-header">
+              <div>
+                <p class="panel-label">Command Sequence</p>
+                <h2>Session Control</h2>
+              </div>
+              <button class="panel-lens" data-drawer-action="session" type="button">Inspect</button>
+            </div>
+
+            <div class="marquee-layout">
+              <div class="session-sequence">
+                <div class="session-code-row">
+                  <div class="session-code-block">
+                    <span class="meta-label">Active Code</span>
+                    <div class="session-code" id="session-code">...</div>
+                  </div>
+                  <div class="session-code-actions">
+                    <button class="control-button ghost-button copy-button" id="copy-session-code" type="button">
+                      Copy
+                    </button>
+                    <button class="control-button ghost-button copy-button" id="share-session" type="button">
+                      Share
+                    </button>
+                  </div>
+                </div>
+                <p class="session-instructions" id="session-instructions">
+                  Loading session…
+                </p>
+                <p class="small-note session-share-note" id="session-share-note">
+                  Shared links are kept for one week by default.
+                </p>
+                <div class="session-meta">
+                  <div class="metric-card compact">
+                    <span class="meta-label">Status</span>
+                    <strong id="session-status">Waiting</strong>
+                  </div>
+                  <div class="metric-card compact">
+                    <span class="meta-label">Message Hash</span>
+                    <strong><a class="hash-link pending" id="session-hash" href="#" rel="noopener noreferrer" target="_blank">Pending</a></strong>
+                  </div>
+                </div>
+              </div>
+
+              <section class="health-pocket" data-drawer-panel="health">
+                <div class="health-pocket__head">
+                  <div>
+                    <p class="panel-label">Current Health</p>
+                    <h2 id="health-label">Waiting</h2>
+                  </div>
+                  <button class="panel-lens" data-drawer-action="health" type="button">Deep Dive</button>
+                </div>
+
+                <div class="health-pocket__content">
+                  <div class="score-ring">
+                    <svg class="score-ring__svg" viewBox="0 0 120 120" aria-hidden="true">
+                      <circle class="score-ring__track" cx="60" cy="60" r="50"></circle>
+                      <circle class="score-ring__fill" cx="60" cy="60" r="50"></circle>
+                    </svg>
+                    <span id="health-percent"><span class="score-num">0</span><span class="score-unit">%</span></span>
+                  </div>
+
+                  <div class="score-grid health-pocket__stats">
+                    <div class="metric-card">
+                      <span class="metric-label">Observers Reached</span>
+                      <strong id="observed-count">0 / 0</strong>
+                    </div>
+                    <div class="metric-card">
+                      <span class="metric-label">Sender</span>
+                      <strong id="sender-name">Pending</strong>
+                    </div>
+                    <div class="metric-card">
+                      <span class="metric-label">Channel</span>
+                      <strong id="channel-name">#health-check</strong>
+                    </div>
+                    <div class="metric-card">
+                      <span class="metric-label">Broker</span>
+                      <strong id="broker-name">Loading</strong>
+                    </div>
+                  </div>
+                </div>
+              </section>
+            </div>
+
+            <div class="message-preview">
+              <span class="meta-label">Matched Message</span>
+              <p id="message-preview">Waiting for your #health-check message.</p>
+            </div>
+          </article>
+        </section>
+
+        <section class="dashboard-grid">
+          <article class="panel map-panel spotlight-panel" id="coverage-map" data-drawer-panel="map">
             <div class="panel-header slim">
               <div>
-                <p class="panel-label">Timeline</p>
-                <h3>When each observer saw it</h3>
+                <p class="panel-label">Coverage Map</p>
+                <h2>Where the observers are</h2>
               </div>
-              <p class="small-note" id="timeline-summary">Waiting for observer reports</p>
+              <div class="panel-actions">
+                <button class="panel-lens" data-drawer-action="map" type="button">Inspect</button>
+              </div>
             </div>
-            <div class="timeline-scale hidden" id="timeline-scale">
-              <span id="timeline-start-label">First receipt</span>
-              <span id="timeline-end-label">Latest receipt</span>
+            <p class="small-note" id="map-observer-note">Waiting for observer coordinates.</p>
+            <div class="empty-state compact hidden" id="map-empty">
+              No saved observer coordinates yet. The app will learn them from MQTT metadata and store them in <code>observer.json</code>.
             </div>
-            <div class="empty-state compact" id="receipt-timeline-empty">
-              Timeline appears after the first observer report.
-            </div>
-            <div class="receipt-timeline" id="receipt-timeline"></div>
-          </div>
-          <div class="empty-state" id="receipts-empty">
-            No observer reports yet.
-          </div>
-          <div class="receipts" id="receipts"></div>
-        </article>
+            <div class="observer-map" id="observer-map"></div>
+          </article>
 
-        <article class="panel wide">
-          <div class="panel-header slim">
-            <div>
-              <p class="panel-label">Recent Sessions</p>
-              <h2>Previous checks</h2>
+          <article class="panel observer-panel" data-drawer-panel="observers" id="observer-targets">
+            <div class="panel-header slim">
+              <div>
+                <p class="panel-label">Observer Set</p>
+                <h2>Observers</h2>
+              </div>
+              <div class="panel-actions">
+                <button class="ghost-button" id="observer-allowlist-clear" type="button">
+                  Default Set
+                </button>
+                <button class="panel-lens" data-drawer-action="observers" type="button">Inspect</button>
+              </div>
             </div>
-          </div>
-          <div class="history-list" id="session-history"></div>
-        </article>
+            <p class="small-note allowlist-note" id="observer-allowlist-note">
+              Default: 0 observers.
+            </p>
+            <div class="observer-selector" id="observer-allowlist"></div>
+            <div class="panel-divider"></div>
+            <div class="panel-header slim">
+              <div>
+                <p class="panel-label">Target</p>
+                <h2>Score Against</h2>
+              </div>
+              <p class="small-note" id="expected-source">Default</p>
+            </div>
+            <div class="observer-badges" id="expected-observers"></div>
+          </article>
+
+          <article class="panel reports-panel ledger-panel" id="observer-reports" data-drawer-panel="reports">
+            <div class="panel-header slim">
+              <div>
+                <p class="panel-label">Observer Reports</p>
+                <h2>Who saw the message</h2>
+              </div>
+              <div class="panel-actions">
+                <p class="small-note" id="active-observer-note">0 active observers</p>
+                <button class="panel-lens" data-drawer-action="reports" type="button">Inspect</button>
+              </div>
+            </div>
+            <div class="timeline-block">
+              <div class="panel-header slim">
+                <div>
+                  <p class="panel-label">Timeline</p>
+                  <h3>When each observer saw it</h3>
+                </div>
+                <p class="small-note" id="timeline-summary">Waiting for observer reports</p>
+              </div>
+              <div class="timeline-scale hidden" id="timeline-scale">
+                <span id="timeline-start-label">First receipt</span>
+                <span id="timeline-end-label">Latest receipt</span>
+              </div>
+              <div class="empty-state compact" id="receipt-timeline-empty">
+                Timeline appears after the first observer report.
+              </div>
+              <div class="receipt-timeline" id="receipt-timeline"></div>
+            </div>
+            <div class="empty-state" id="receipts-empty">
+              No observer reports yet.
+            </div>
+            <div class="receipts" id="receipts"></div>
+
+            <div class="ledger-divider" aria-hidden="true"></div>
+            <div class="panel-header slim ledger-history-head">
+              <div>
+                <p class="panel-label">Recent Sessions</p>
+                <h2>Previous checks</h2>
+              </div>
+              <button class="panel-lens" data-drawer-action="history" type="button">Inspect</button>
+            </div>
+            <div class="history-list" id="session-history"></div>
+          </article>
+        </section>
+
+        <footer class="site-footer">
+          <p class="small-note">
+            <a href="https://github.com/yellowcooln/meshcore-health-check/blob/main/CHANGES.md" id="site-version-note" rel="noopener noreferrer" target="_blank">Version: v0.0.0</a>
+            <span aria-hidden="true"> · </span>
+            Source:
+            <a href="https://github.com/yellowcooln/meshcore-health-check" id="repo-note-link" rel="noopener noreferrer" target="_blank">yellowcooln/meshcore-health-check</a>
+          </p>
+        </footer>
       </section>
-      <footer class="site-footer">
-        <p class="small-note">
-          <a href="https://github.com/yellowcooln/meshcore-health-check/blob/main/CHANGES.md" id="site-version-note" rel="noopener noreferrer" target="_blank">Version: v0.0.0</a>
-          <span aria-hidden="true"> · </span>
-          Source:
-          <a href="https://github.com/yellowcooln/meshcore-health-check" id="repo-note-link" rel="noopener noreferrer" target="_blank">yellowcooln/meshcore-health-check</a>
-        </p>
-      </footer>
     </main>
+
+    <div class="drawer-scrim" id="drawer-scrim" aria-hidden="true"></div>
+    <aside class="detail-drawer" id="detail-drawer" aria-hidden="true">
+      <div class="drawer-head">
+        <div>
+          <p class="panel-label" id="drawer-meta">Deep Dive</p>
+          <h2 id="drawer-title">Session Diagnostics</h2>
+        </div>
+        <button class="drawer-close ghost-button" id="drawer-close" type="button">Close</button>
+      </div>
+      <div class="drawer-body" id="drawer-body"></div>
+    </aside>
 
     <script src="/vendor/leaflet/leaflet.js" defer></script>
     <script type="module" src="/app.js"></script>

--- a/public/landing.css
+++ b/public/landing.css
@@ -1,64 +1,170 @@
 body.landing-body {
   margin: 0;
   min-height: 100vh;
+  overflow: hidden;
+  color: #eaf4ff;
+  font-family: "Geist", "Avenir Next", "Segoe UI Variable Text", "Segoe UI", sans-serif;
   background:
-    radial-gradient(circle at top, rgba(230, 182, 74, 0.24), transparent 26%),
-    linear-gradient(160deg, #0b0f0c 0%, #121a16 52%, #1a231e 100%);
-  color: #eff5ef;
-  font-family: InterVariable, "Segoe UI Variable Text", "Segoe UI", system-ui, -apple-system, sans-serif;
+    radial-gradient(circle at 16% 18%, rgba(123, 214, 255, 0.2), transparent 26%),
+    radial-gradient(circle at 82% 22%, rgba(103, 244, 161, 0.12), transparent 18%),
+    radial-gradient(circle at 50% 88%, rgba(255, 95, 109, 0.1), transparent 20%),
+    linear-gradient(135deg, #040a12 0%, #08111d 42%, #06101a 100%);
+  -webkit-text-size-adjust: 100%;
+}
+
+.landing-grid,
+.landing-grid::before,
+.landing-grid::after {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+}
+
+.landing-grid {
+  background:
+    linear-gradient(rgba(123, 214, 255, 0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(123, 214, 255, 0.04) 1px, transparent 1px);
+  background-size: 72px 72px;
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.9), transparent);
+}
+
+.landing-grid::before,
+.landing-grid::after {
+  content: "";
+}
+
+.landing-grid::before {
+  background: radial-gradient(circle, rgba(123, 214, 255, 0.16), transparent 66%);
+  inset: auto auto 10% 62%;
+  width: min(38vw, 520px);
+  height: min(38vw, 520px);
+  filter: blur(14px);
+}
+
+.landing-grid::after {
+  background: linear-gradient(180deg, transparent, rgba(255, 255, 255, 0.04), transparent);
+  opacity: 0.3;
+  transform: translateY(-100%);
+  animation: scan 11s linear infinite;
 }
 
 .landing-shell {
+  position: relative;
   min-height: 100vh;
   display: grid;
   place-items: center;
   padding: 24px;
 }
 
+.landing-halo {
+  position: absolute;
+  width: min(44vw, 580px);
+  height: min(44vw, 580px);
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(123, 214, 255, 0.18), transparent 70%);
+  filter: blur(10px);
+  pointer-events: none;
+}
+
 .landing-card {
-  width: min(520px, 100%);
-  background: rgba(23, 31, 27, 0.94);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 26px;
-  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.28);
+  position: relative;
+  display: grid;
+  gap: 22px;
+  width: min(760px, 100%);
   padding: 28px;
-  text-align: center;
+  border-radius: 30px;
+  border: 1px solid rgba(142, 182, 255, 0.14);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.015)),
+    rgba(8, 19, 34, 0.76);
+  box-shadow: 0 28px 90px rgba(0, 0, 0, 0.36);
+  backdrop-filter: blur(28px) saturate(140%);
+  -webkit-backdrop-filter: blur(28px) saturate(140%);
+}
+
+.landing-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.045);
+  pointer-events: none;
+}
+
+.landing-brand {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 18px;
+  align-items: center;
 }
 
 .landing-logo {
-  width: 84px;
-  height: 84px;
-  margin: 0 auto 16px;
-  display: block;
-}
-
-.landing-eyebrow,
-.landing-note,
-.landing-status {
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  font-size: 0.72rem;
-  color: #a7b6aa;
+  width: 88px;
+  height: 88px;
+  border-radius: 24px;
+  padding: 12px;
+  border: 1px solid rgba(194, 245, 255, 0.14);
+  background:
+    linear-gradient(145deg, rgba(123, 214, 255, 0.18), rgba(103, 244, 161, 0.06)),
+    rgba(255, 255, 255, 0.04);
+  box-shadow: 0 0 36px rgba(123, 214, 255, 0.16);
 }
 
 .landing-title {
-  margin: 0;
-  font-family: ui-serif, Georgia, Cambria, "Times New Roman", serif;
-  font-size: clamp(1.8rem, 4.6vw, 2.7rem);
-  line-height: 1.02;
+  margin: 6px 0 0;
+  font-size: clamp(2rem, 4.4vw, 3.35rem);
+  line-height: 0.96;
+  letter-spacing: -0.04em;
   text-wrap: balance;
 }
 
 .landing-copy {
-  margin: 14px auto 0;
-  max-width: 40ch;
-  color: #d9e4db;
-  line-height: 1.7;
+  margin: 0;
+  max-width: 54ch;
+  color: #b9c9dd;
+  font-size: 1rem;
+  line-height: 1.75;
+}
+
+.landing-panels {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 0;
+}
+
+.landing-module,
+.landing-turnstile-shell {
+  border-radius: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.02)),
+    rgba(255, 255, 255, 0.02);
+}
+
+.landing-module {
+  padding: 16px;
+}
+
+.landing-module strong {
+  display: block;
+  margin-top: 10px;
+  font-size: 1.05rem;
+}
+
+.landing-module p {
+  margin: 10px 0 0;
+  color: #b9c9dd;
+  line-height: 1.6;
+}
+
+.landing-turnstile-shell {
+  margin-top: 0;
+  padding: 18px;
 }
 
 .landing-turnstile {
-  margin: 24px auto 0;
-  min-height: 74px;
+  min-height: 76px;
   display: grid;
   place-items: center;
 }
@@ -66,18 +172,75 @@ body.landing-body {
 .landing-status {
   margin-top: 16px;
   min-height: 1.2rem;
+  color: #8fa5c2;
 }
 
 .landing-status.error {
-  color: #f07d60;
+  color: #ff9b92;
 }
 
 .landing-status.success {
-  color: #6fd96a;
+  color: #67f4a1;
 }
 
-@media (max-width: 560px) {
+@keyframes scan {
+  0% {
+    transform: translateY(-100%);
+  }
+  100% {
+    transform: translateY(100%);
+  }
+}
+
+@media (max-width: 720px) {
+  body.landing-body {
+    overflow-y: auto;
+  }
+
+  .landing-shell {
+    padding: 16px;
+  }
+
   .landing-card {
     padding: 22px 18px;
+    border-radius: 24px;
+  }
+
+  .landing-brand,
+  .landing-panels {
+    grid-template-columns: 1fr;
+  }
+
+  .landing-logo {
+    width: 78px;
+    height: 78px;
+  }
+
+  .landing-title {
+    font-size: clamp(1.7rem, 9vw, 2.4rem);
+  }
+
+  .landing-copy {
+    line-height: 1.55;
+  }
+
+  .landing-brand {
+    order: 0;
+  }
+
+  .landing-copy {
+    order: 1;
+  }
+
+  .landing-turnstile-shell {
+    order: 2;
+  }
+
+  .landing-status {
+    order: 3;
+  }
+
+  .landing-panels {
+    order: 4;
   }
 }

--- a/public/landing.html
+++ b/public/landing.html
@@ -19,21 +19,45 @@
     <link rel="icon" type="image/png" href="/logo.png">
     <link rel="apple-touch-icon" href="/logo.png">
     <link rel="manifest" href="/manifest.webmanifest">
-    <meta name="theme-color" content="#101512">
+    <meta name="theme-color" content="#07111d">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <link rel="stylesheet" href="/landing.css">
   </head>
   <body class="landing-body">
+    <div class="landing-grid" aria-hidden="true"></div>
     <main class="landing-shell">
+      <section class="landing-halo" aria-hidden="true"></section>
+
       <section class="landing-card">
-        <img class="landing-logo" src="/logo.png" alt="Mesh Health Check">
-        <p class="landing-eyebrow" id="landing-eyebrow">Human Verification</p>
-        <h1 class="landing-title" id="landing-title">One quick check before the dashboard.</h1>
+        <div class="landing-brand">
+          <img class="landing-logo" src="/logo.png" alt="Mesh Health Check">
+          <div>
+            <p class="landing-eyebrow" id="landing-eyebrow">Human Verification</p>
+            <h1 class="landing-title" id="landing-title">One quick check before the dashboard.</h1>
+          </div>
+        </div>
+
         <p class="landing-copy" id="landing-copy">
           Complete the Turnstile challenge to open Mesh Health Check and generate
           test codes for <strong>#health-check</strong>.
         </p>
-        <div class="landing-turnstile" id="turnstile-container">Loading verification…</div>
+
+        <div class="landing-panels">
+          <section class="landing-module">
+            <span class="landing-module__label">Access Layer</span>
+            <strong>Secure Operator Entry</strong>
+            <p>Verify once, then move directly into the live mesh control center.</p>
+          </section>
+          <section class="landing-module">
+            <span class="landing-module__label">NOC Style</span>
+            <strong>Glass-Dark Console</strong>
+            <p>Optimized for quick field checks on mobile and persistent monitoring on larger displays.</p>
+          </section>
+        </div>
+
+        <div class="landing-turnstile-shell">
+          <div class="landing-turnstile" id="turnstile-container">Loading verification…</div>
+        </div>
         <p class="landing-status" id="landing-status">Preparing challenge…</p>
       </section>
     </main>

--- a/public/share.html
+++ b/public/share.html
@@ -19,198 +19,365 @@
     <link rel="icon" type="image/png" href="/logo.png">
     <link rel="apple-touch-icon" href="/logo.png">
     <link rel="manifest" href="/manifest.webmanifest">
-    <meta name="theme-color" content="#101512">
+    <meta name="theme-color" content="#07111d">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <link rel="stylesheet" href="/vendor/leaflet/leaflet.css">
     <link rel="stylesheet" href="/styles.css">
   </head>
-  <body data-page-mode="share">
-    <main class="shell">
-      <section class="hero">
-        <div class="hero-copy">
-          <p class="eyebrow" id="hero-eyebrow">Shared Result</p>
-          <h1 id="hero-title">Observer coverage someone shared with you.</h1>
-          <p class="lede">
-            <span id="hero-description-prefix">This page is read-only. Review the result from</span>
-            <strong id="hero-channel">#health-check</strong>
-            <span id="hero-description-suffix">or open the full dashboard to run your own check.</span>
-          </p>
+  <body class="noc-body" data-page-mode="share" data-ui-theme="dark">
+    <div class="screen-glow" aria-hidden="true"></div>
+    <main class="noc-shell">
+      <section class="workspace">
+        <div class="splash-scene" aria-hidden="true">
+          <span class="splash-scene__mesh"></span>
+          <span class="splash-scene__beam"></span>
+          <span class="splash-scene__grid"></span>
+          <span class="splash-scene__ring splash-scene__ring--left"></span>
+          <span class="splash-scene__ring splash-scene__ring--right"></span>
+          <span class="splash-scene__badge splash-scene__badge--one">Retained session</span>
+          <span class="splash-scene__badge splash-scene__badge--two">Shared briefing</span>
         </div>
-        <div class="hero-card share-hero-card" id="session-card">
-          <div class="hero-topline">
-            <span class="pill" id="mqtt-pill">Shared Link</span>
-            <div class="hero-actions">
-              <button class="ghost-button hidden" id="install-app-button" type="button">
-                Install App
-              </button>
-              <a class="ghost-button hidden" href="#" id="external-link" rel="noopener noreferrer" target="_blank">External Link</a>
-              <a class="ghost-button" href="/app" id="start-own-check-link">Run Your Own Check</a>
-              <button class="ghost-button hidden" id="new-session-button" type="button">
-                New Code
-              </button>
+        <section class="hero-stage">
+          <article class="hero-panel hero-stage__lead">
+            <div class="dock-brand">
+              <div class="brand-orb" aria-hidden="true">
+                <span></span>
+              </div>
+              <div class="brand-copy">
+                <p class="eyebrow" id="hero-eyebrow">Shared Result</p>
+                <h1 id="hero-title">Observer coverage someone shared with you.</h1>
+              </div>
             </div>
-          </div>
-          <div class="session-code-row">
-            <div class="session-code" id="session-code">...</div>
-            <div class="session-code-actions">
-              <button class="ghost-button copy-button" id="copy-session-code" type="button">
-                Copy
-              </button>
-              <button class="ghost-button copy-button" id="share-session" type="button">
-                Share
-              </button>
-            </div>
-          </div>
-          <p class="session-instructions" id="session-instructions">
-            Loading shared result…
-          </p>
-          <p class="small-note session-share-note" id="session-share-note">
-            Shared links are kept for one week by default.
-          </p>
-          <div class="session-meta">
-            <div>
-              <span class="meta-label">Status</span>
-              <strong id="session-status">Waiting</strong>
-            </div>
-            <div>
-              <span class="meta-label">Message Hash</span>
-              <strong><a class="hash-link pending" id="session-hash" href="#" rel="noopener noreferrer" target="_blank">Pending</a></strong>
-            </div>
-          </div>
-        </div>
-      </section>
 
-      <section class="dashboard">
-        <article class="panel score-panel">
-          <div class="panel-header">
-            <div>
-              <p class="panel-label">Shared Health</p>
-              <h2 id="health-label">Waiting</h2>
-            </div>
-            <div class="score-ring">
-              <svg class="score-ring__svg" viewBox="0 0 120 120" aria-hidden="true">
-                <circle class="score-ring__track" cx="60" cy="60" r="50"/>
-                <circle class="score-ring__fill" cx="60" cy="60" r="50"/>
-              </svg>
-              <span id="health-percent"><span class="score-num">0</span><span class="score-unit">%</span></span>
-            </div>
-          </div>
-          <div class="score-grid">
-            <div class="metric-card">
-              <span class="metric-label">Observers Reached</span>
-              <strong id="observed-count">0 / 0</strong>
-            </div>
-            <div class="metric-card">
-              <span class="metric-label">Sender</span>
-              <strong id="sender-name">Pending</strong>
-            </div>
-            <div class="metric-card">
-              <span class="metric-label">Channel</span>
-              <strong id="channel-name">#health-check</strong>
-            </div>
-            <div class="metric-card">
-              <span class="metric-label">Broker</span>
-              <strong id="broker-name">Loading</strong>
-            </div>
-          </div>
-          <div class="message-preview">
-            <span class="meta-label">Matched Message</span>
-            <p id="message-preview">Waiting for a shared result.</p>
-          </div>
-        </article>
+            <p class="dock-lede lede">
+              <span id="hero-description-prefix">This page is read-only. Review the result from</span>
+              <strong id="hero-channel">#health-check</strong>
+              <span id="hero-description-suffix">or open the full dashboard to run your own check.</span>
+            </p>
 
-        <article class="panel share-hidden">
-          <div class="panel-header slim">
-            <div>
-              <p class="panel-label">Observer Set</p>
-              <h2>Observers</h2>
+            <div class="hero-stage__pulse">
+              <span class="hero-stage__pulse-dot" aria-hidden="true"></span>
+              <div>
+                <p class="panel-label">Shared Surface</p>
+                <p class="small-note">A retained session rendered as one continuous briefing, with the map and trace detail still in reach.</p>
+              </div>
             </div>
-            <button class="ghost-button" id="observer-allowlist-clear" type="button">
-              Default Set
+
+            <nav class="dock-nav" aria-label="Dashboard sections">
+              <a class="dock-nav__item" href="#command-center">
+                <span>N0</span>
+                <strong>Control</strong>
+              </a>
+              <a class="dock-nav__item" href="#health-at-a-glance">
+                <span>N1</span>
+                <strong>Glance</strong>
+              </a>
+              <a class="dock-nav__item" href="#coverage-map">
+                <span>N2</span>
+                <strong>Map</strong>
+              </a>
+              <a class="dock-nav__item" href="#observer-reports">
+                <span>N3</span>
+                <strong>Logs</strong>
+              </a>
+            </nav>
+          </article>
+
+          <article class="hero-panel hero-stage__brief">
+            <div class="toolbar-copy">
+              <p class="toolbar-label">Shared Control Center</p>
+              <div>
+                <h2>Health at a glance</h2>
+                <p>Review the retained session, inspect technical traces, and step into a fresh live check only when you need it.</p>
+              </div>
+            </div>
+
+            <div class="dock-status-stack">
+              <span class="pill status-pill" id="mqtt-pill">Shared Link</span>
+              <div class="dock-note">
+                <span class="meta-label">Share Mode</span>
+                <strong id="network-window">Read-only diagnostics</strong>
+              </div>
+            </div>
+
+            <div class="dock-meta hero-stage__meta-strip">
+              <div class="dock-meta__item">
+                <span class="meta-label">Console</span>
+                <strong>Shared Session Review</strong>
+              </div>
+              <div class="dock-meta__item">
+                <span class="meta-label">Mode</span>
+                <strong id="mode-label">Dark Review Surface</strong>
+              </div>
+            </div>
+          </article>
+
+          <div class="hero-actions-stack hero-stage__action-rail">
+            <details class="action-menu" id="action-menu">
+              <summary class="control-button ghost-button action-menu__button">Menu</summary>
+              <div class="action-menu__panel">
+                <button class="control-button ghost-button action-menu__item" id="ui-theme-toggle" type="button">
+                  Light Mode
+                </button>
+                <button class="control-button ghost-button action-menu__item hidden" id="install-app-button" type="button">
+                  Install App
+                </button>
+                <a class="control-button ghost-button action-menu__item hidden" href="#" id="external-link" rel="noopener noreferrer" target="_blank">External Link</a>
+              </div>
+            </details>
+            <a class="control-button primary-button" href="/app" id="start-own-check-link">Run Your Own Check</a>
+            <button class="control-button primary-button hidden" id="new-session-button" type="button">
+              New Code
             </button>
           </div>
-          <p class="small-note allowlist-note" id="observer-allowlist-note">
-            Default: 0 observers.
-          </p>
-          <div class="observer-selector" id="observer-allowlist"></div>
-          <div class="panel-divider"></div>
-          <div class="panel-header slim">
-            <div>
-              <p class="panel-label">Target</p>
-              <h2>Score Against</h2>
-            </div>
-            <p class="small-note" id="expected-source">Default</p>
-          </div>
-          <div class="observer-badges" id="expected-observers"></div>
-        </article>
 
-        <article class="panel wide">
-          <div class="panel-header slim">
-            <div>
-              <p class="panel-label">Coverage Map</p>
-              <h2>Where the observers are</h2>
+          <section class="glance-grid telemetry-strip" id="health-at-a-glance">
+            <article class="glance-card telemetry-strip__item" data-drawer-panel="transport">
+            <div class="glance-card__head">
+              <span class="panel-label">Transport</span>
+              <button class="panel-lens" data-drawer-action="transport" type="button">Inspect</button>
             </div>
-            <button class="ghost-button" id="map-theme-toggle" type="button">
-              Light Map
-            </button>
-          </div>
-          <p class="small-note" id="map-observer-note">Waiting for observer coordinates.</p>
-          <div class="empty-state compact hidden" id="map-empty">
-            No saved observer coordinates yet. The app will learn them from MQTT metadata and store them in <code>observer.json</code>.
-          </div>
-          <div class="observer-map" id="observer-map"></div>
-        </article>
+            <strong class="glance-card__value" id="network-state">Shared</strong>
+            <div class="sparkline" id="observer-sparkline" aria-hidden="true"></div>
+            <p class="small-note" id="observer-density-label">Awaiting observer directory.</p>
+            </article>
 
-        <article class="panel wide">
-          <div class="panel-header slim">
-            <div>
-              <p class="panel-label">Observer Reports</p>
-              <h2>Who saw the message</h2>
+            <article class="glance-card telemetry-strip__item" data-drawer-panel="map">
+            <div class="glance-card__head">
+              <span class="panel-label">Mapped Nodes</span>
+              <button class="panel-lens" data-drawer-action="map" type="button">Inspect</button>
             </div>
-            <p class="small-note" id="active-observer-note">0 active observers</p>
-          </div>
-          <div class="timeline-block">
+            <strong class="glance-card__value" id="observer-density">0 / 0</strong>
+            <div class="sparkline" id="observer-load-sparkline" aria-hidden="true"></div>
+            <p class="small-note" id="observer-density-detail">No observer telemetry yet.</p>
+            </article>
+
+            <article class="glance-card telemetry-strip__item" data-drawer-panel="health">
+            <div class="glance-card__head">
+              <span class="panel-label">Signal Quality</span>
+              <button class="panel-lens" data-drawer-action="health" type="button">Inspect</button>
+            </div>
+            <strong class="glance-card__value" id="signal-quality">--</strong>
+            <div class="sparkline" id="signal-sparkline" aria-hidden="true"></div>
+            <p class="small-note" id="signal-quality-label">Awaiting telemetry.</p>
+            </article>
+
+            <article class="glance-card telemetry-strip__item" data-drawer-panel="reports">
+            <div class="glance-card__head">
+              <span class="panel-label">Receipt Spread</span>
+              <button class="panel-lens" data-drawer-action="reports" type="button">Inspect</button>
+            </div>
+            <strong class="glance-card__value" id="latency-score">--</strong>
+            <div class="sparkline" id="latency-sparkline" aria-hidden="true"></div>
+            <p class="small-note" id="latency-label">Awaiting receipt spread.</p>
+            </article>
+          </section>
+        </section>
+
+        <section class="command-grid">
+          <article class="panel command-panel marquee-panel share-hero-card" data-drawer-panel="session" id="command-center">
+            <div class="panel-header">
+              <div>
+                <p class="panel-label">Retained Session</p>
+                <h2>Shared Control</h2>
+              </div>
+              <button class="panel-lens" data-drawer-action="session" type="button">Inspect</button>
+            </div>
+
+            <div class="marquee-layout">
+              <div class="session-sequence">
+                <div class="session-code-row">
+                  <div class="session-code-block">
+                    <span class="meta-label">Shared Code</span>
+                    <div class="session-code" id="session-code">...</div>
+                  </div>
+                  <div class="session-code-actions">
+                    <button class="control-button ghost-button copy-button" id="copy-session-code" type="button">
+                      Copy
+                    </button>
+                    <button class="control-button ghost-button copy-button" id="share-session" type="button">
+                      Share
+                    </button>
+                  </div>
+                </div>
+                <p class="session-instructions" id="session-instructions">
+                  Loading shared result…
+                </p>
+                <p class="small-note session-share-note" id="session-share-note">
+                  Shared links are kept for one week by default.
+                </p>
+                <div class="session-meta">
+                  <div class="metric-card compact">
+                    <span class="meta-label">Status</span>
+                    <strong id="session-status">Waiting</strong>
+                  </div>
+                  <div class="metric-card compact">
+                    <span class="meta-label">Message Hash</span>
+                    <strong><a class="hash-link pending" id="session-hash" href="#" rel="noopener noreferrer" target="_blank">Pending</a></strong>
+                  </div>
+                </div>
+              </div>
+
+              <section class="health-pocket" data-drawer-panel="health">
+                <div class="health-pocket__head">
+                  <div>
+                    <p class="panel-label">Shared Health</p>
+                    <h2 id="health-label">Waiting</h2>
+                  </div>
+                  <button class="panel-lens" data-drawer-action="health" type="button">Deep Dive</button>
+                </div>
+
+                <div class="health-pocket__content">
+                  <div class="score-ring">
+                    <svg class="score-ring__svg" viewBox="0 0 120 120" aria-hidden="true">
+                      <circle class="score-ring__track" cx="60" cy="60" r="50"></circle>
+                      <circle class="score-ring__fill" cx="60" cy="60" r="50"></circle>
+                    </svg>
+                    <span id="health-percent"><span class="score-num">0</span><span class="score-unit">%</span></span>
+                  </div>
+
+                  <div class="score-grid health-pocket__stats">
+                    <div class="metric-card">
+                      <span class="metric-label">Observers Reached</span>
+                      <strong id="observed-count">0 / 0</strong>
+                    </div>
+                    <div class="metric-card">
+                      <span class="metric-label">Sender</span>
+                      <strong id="sender-name">Pending</strong>
+                    </div>
+                    <div class="metric-card">
+                      <span class="metric-label">Channel</span>
+                      <strong id="channel-name">#health-check</strong>
+                    </div>
+                    <div class="metric-card">
+                      <span class="metric-label">Broker</span>
+                      <strong id="broker-name">Loading</strong>
+                    </div>
+                  </div>
+                </div>
+              </section>
+            </div>
+
+            <div class="message-preview">
+              <span class="meta-label">Matched Message</span>
+              <p id="message-preview">Waiting for a shared result.</p>
+            </div>
+          </article>
+        </section>
+
+        <section class="dashboard-grid">
+          <article class="panel map-panel spotlight-panel" id="coverage-map" data-drawer-panel="map">
             <div class="panel-header slim">
               <div>
-                <p class="panel-label">Timeline</p>
-                <h3>When each observer saw it</h3>
+                <p class="panel-label">Coverage Map</p>
+                <h2>Where the observers are</h2>
               </div>
-              <p class="small-note" id="timeline-summary">Waiting for observer reports</p>
+              <div class="panel-actions">
+                <button class="panel-lens" data-drawer-action="map" type="button">Inspect</button>
+              </div>
             </div>
-            <div class="timeline-scale hidden" id="timeline-scale">
-              <span id="timeline-start-label">First receipt</span>
-              <span id="timeline-end-label">Latest receipt</span>
+            <p class="small-note" id="map-observer-note">Waiting for observer coordinates.</p>
+            <div class="empty-state compact hidden" id="map-empty">
+              No saved observer coordinates yet. The app will learn them from MQTT metadata and store them in <code>observer.json</code>.
             </div>
-            <div class="empty-state compact" id="receipt-timeline-empty">
-              Timeline appears after the first observer report.
-            </div>
-            <div class="receipt-timeline" id="receipt-timeline"></div>
-          </div>
-          <div class="empty-state" id="receipts-empty">
-            No observer reports yet.
-          </div>
-          <div class="receipts" id="receipts"></div>
-        </article>
+            <div class="observer-map" id="observer-map"></div>
+          </article>
 
-        <article class="panel wide share-hidden">
-          <div class="panel-header slim">
-            <div>
-              <p class="panel-label">Recent Sessions</p>
-              <h2>Previous checks</h2>
+          <article class="panel observer-panel share-hidden" data-drawer-panel="observers" id="observer-targets">
+            <div class="panel-header slim">
+              <div>
+                <p class="panel-label">Observer Set</p>
+                <h2>Observers</h2>
+              </div>
+              <div class="panel-actions">
+                <button class="ghost-button" id="observer-allowlist-clear" type="button">
+                  Default Set
+                </button>
+                <button class="panel-lens" data-drawer-action="observers" type="button">Inspect</button>
+              </div>
             </div>
-          </div>
-          <div class="history-list" id="session-history"></div>
-        </article>
+            <p class="small-note allowlist-note" id="observer-allowlist-note">
+              Default: 0 observers.
+            </p>
+            <div class="observer-selector" id="observer-allowlist"></div>
+            <div class="panel-divider"></div>
+            <div class="panel-header slim">
+              <div>
+                <p class="panel-label">Target</p>
+                <h2>Score Against</h2>
+              </div>
+              <p class="small-note" id="expected-source">Default</p>
+            </div>
+            <div class="observer-badges" id="expected-observers"></div>
+          </article>
+
+          <article class="panel reports-panel ledger-panel" id="observer-reports" data-drawer-panel="reports">
+            <div class="panel-header slim">
+              <div>
+                <p class="panel-label">Observer Reports</p>
+                <h2>Who saw the message</h2>
+              </div>
+              <div class="panel-actions">
+                <p class="small-note" id="active-observer-note">0 active observers</p>
+                <button class="panel-lens" data-drawer-action="reports" type="button">Inspect</button>
+              </div>
+            </div>
+            <div class="timeline-block">
+              <div class="panel-header slim">
+                <div>
+                  <p class="panel-label">Timeline</p>
+                  <h3>When each observer saw it</h3>
+                </div>
+                <p class="small-note" id="timeline-summary">Waiting for observer reports</p>
+              </div>
+              <div class="timeline-scale hidden" id="timeline-scale">
+                <span id="timeline-start-label">First receipt</span>
+                <span id="timeline-end-label">Latest receipt</span>
+              </div>
+              <div class="empty-state compact" id="receipt-timeline-empty">
+                Timeline appears after the first observer report.
+              </div>
+              <div class="receipt-timeline" id="receipt-timeline"></div>
+            </div>
+            <div class="empty-state" id="receipts-empty">
+              No observer reports yet.
+            </div>
+            <div class="receipts" id="receipts"></div>
+
+            <div class="ledger-divider share-hidden" aria-hidden="true"></div>
+            <div class="panel-header slim ledger-history-head share-hidden">
+              <div>
+                <p class="panel-label">Recent Sessions</p>
+                <h2>Previous checks</h2>
+              </div>
+              <button class="panel-lens" data-drawer-action="history" type="button">Inspect</button>
+            </div>
+            <div class="history-list" id="session-history"></div>
+          </article>
+        </section>
+
+        <footer class="site-footer">
+          <p class="small-note">
+            <a href="https://github.com/yellowcooln/meshcore-health-check/blob/main/CHANGES.md" id="site-version-note" rel="noopener noreferrer" target="_blank">Version: v0.0.0</a>
+            <span aria-hidden="true"> · </span>
+            Source:
+            <a href="https://github.com/yellowcooln/meshcore-health-check" id="repo-note-link" rel="noopener noreferrer" target="_blank">yellowcooln/meshcore-health-check</a>
+          </p>
+        </footer>
       </section>
-      <footer class="site-footer">
-        <p class="small-note">
-          <a href="https://github.com/yellowcooln/meshcore-health-check/blob/main/CHANGES.md" id="site-version-note" rel="noopener noreferrer" target="_blank">Version: v0.0.0</a>
-          <span aria-hidden="true"> · </span>
-          Source:
-          <a href="https://github.com/yellowcooln/meshcore-health-check" id="repo-note-link" rel="noopener noreferrer" target="_blank">yellowcooln/meshcore-health-check</a>
-        </p>
-      </footer>
     </main>
+
+    <div class="drawer-scrim" id="drawer-scrim" aria-hidden="true"></div>
+    <aside class="detail-drawer" id="detail-drawer" aria-hidden="true">
+      <div class="drawer-head">
+        <div>
+          <p class="panel-label" id="drawer-meta">Deep Dive</p>
+          <h2 id="drawer-title">Session Diagnostics</h2>
+        </div>
+        <button class="drawer-close ghost-button" id="drawer-close" type="button">Close</button>
+      </div>
+      <div class="drawer-body" id="drawer-body"></div>
+    </aside>
 
     <script src="/vendor/leaflet/leaflet.js" defer></script>
     <script type="module" src="/app.js"></script>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,112 +1,875 @@
 :root {
-  --bg: #101512;
-  --panel: rgba(23, 31, 27, 0.92);
-  --panel-strong: rgba(31, 42, 36, 0.98);
-  --panel-soft: rgba(255, 255, 255, 0.04);
-  --line: rgba(255, 255, 255, 0.08);
-  --text: #eff5ef;
-  --muted: #a7b6aa;
-  --accent: #e6b64a;
-  --accent-strong: #ffcc63;
-  --good: #6fd96a;
-  --fair: #d7b84f;
-  --poor: #f07d60;
-  --shadow: 0 24px 80px rgba(0, 0, 0, 0.28);
-  --radius: 26px;
-  font-family: InterVariable, "Segoe UI Variable Text", "Segoe UI", system-ui, -apple-system, sans-serif;
+  --bg: #060a11;
+  --bg-deep: #0a1018;
+  --bg-alt: #121a26;
+  --panel: rgba(15, 22, 34, 0.86);
+  --panel-strong: rgba(13, 20, 31, 0.96);
+  --panel-soft: rgba(123, 177, 255, 0.07);
+  --panel-overlay: linear-gradient(180deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.01));
+  --line: rgba(173, 196, 228, 0.11);
+  --line-strong: rgba(173, 196, 228, 0.2);
+  --text: #edf2fa;
+  --muted: #8f9fb7;
+  --muted-strong: #c5d0df;
+  --accent: #8db6ff;
+  --accent-strong: #dbe7ff;
+  --good: #67f4a1;
+  --good-glow: rgba(103, 244, 161, 0.34);
+  --fair: #ffbe5c;
+  --fair-glow: rgba(255, 190, 92, 0.32);
+  --poor: #ff5f6d;
+  --poor-glow: rgba(255, 95, 109, 0.32);
+  --shadow: 0 24px 90px rgba(0, 0, 0, 0.34);
+  --radius-xl: 26px;
+  --radius-lg: 20px;
+  --radius-md: 16px;
+  --radius-sm: 12px;
+  --font-sans: "Geist", "Avenir Next", "Segoe UI Variable Text", "Segoe UI", sans-serif;
+  --font-mono: "JetBrains Mono", "SFMono-Regular", "SF Mono", ui-monospace, monospace;
+  --ring-color: var(--accent-strong);
   color: var(--text);
+  font-family: var(--font-sans);
 }
 
 * {
   box-sizing: border-box;
 }
 
+html {
+  scroll-behavior: smooth;
+  -webkit-text-size-adjust: 100%;
+}
+
 body {
   margin: 0;
   min-height: 100vh;
   background:
-    radial-gradient(circle at top left, rgba(230, 182, 74, 0.2), transparent 28%),
-    radial-gradient(circle at 85% 15%, rgba(111, 217, 106, 0.16), transparent 22%),
-    linear-gradient(160deg, #0b0f0c 0%, #121a16 52%, #1a231e 100%);
+    radial-gradient(circle at 18% 0%, rgba(141, 182, 255, 0.14), transparent 26%),
+    radial-gradient(circle at 100% 12%, rgba(255, 190, 92, 0.08), transparent 20%),
+    linear-gradient(180deg, #070b12 0%, #0a0f17 52%, #070b12 100%);
   color: var(--text);
+  font-family: var(--font-sans);
+  overflow-x: hidden;
 }
 
-.shell {
-  width: min(1220px, calc(100vw - 32px));
-  margin: 0 auto;
-  padding: 36px 0 52px;
+body::before,
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: -1;
 }
 
-.hero {
+body::before {
+  background:
+    linear-gradient(rgba(255, 255, 255, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.025) 1px, transparent 1px);
+  background-size: 96px 96px;
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.85), transparent 100%);
+}
+
+body::after {
+  background:
+    radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.08), transparent 24%),
+    radial-gradient(circle at 80% 35%, rgba(255, 255, 255, 0.05), transparent 18%),
+    radial-gradient(circle at 50% 70%, rgba(255, 255, 255, 0.06), transparent 20%);
+  opacity: 0.3;
+  filter: blur(90px);
+}
+
+a {
+  color: inherit;
+}
+
+a,
+button,
+input,
+label,
+.dock-nav__item,
+.panel-lens,
+.ghost-button,
+.primary-button {
+  min-height: 44px;
+}
+
+:focus-visible {
+  outline: 2px solid rgba(194, 245, 255, 0.88);
+  outline-offset: 2px;
+}
+
+code {
+  padding: 0.2rem 0.38rem;
+  border: 1px solid rgba(194, 245, 255, 0.12);
+  border-radius: 0.55rem;
+  background: rgba(194, 245, 255, 0.06);
+  color: var(--accent-strong);
+  font-family: var(--font-mono);
+  font-size: 0.88em;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.screen-glow {
+  position: fixed;
+  inset: auto 6% 8% auto;
+  width: min(34vw, 480px);
+  height: min(34vw, 480px);
+  border-radius: 999px;
+  background: radial-gradient(circle, rgba(141, 182, 255, 0.18), transparent 72%);
+  filter: blur(20px);
+  pointer-events: none;
+  z-index: 0;
+  animation: drift 18s ease-in-out infinite;
+}
+
+.noc-shell {
+  position: relative;
+  z-index: 1;
   display: grid;
-  grid-template-columns: 1.2fr 0.9fr;
-  gap: 24px;
+  grid-template-columns: 1fr;
+  gap: 18px;
+  width: min(1480px, calc(100vw - 40px));
+  margin: 0 auto;
+  padding: 24px 0 52px;
+}
+
+.command-dock,
+.toolbar,
+.hero-panel,
+.glance-card,
+.panel,
+.detail-drawer {
+  position: relative;
+  border: 1px solid var(--line);
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(26px) saturate(140%);
+  -webkit-backdrop-filter: blur(26px) saturate(140%);
+}
+
+.command-dock::before,
+.toolbar::before,
+.hero-panel::before,
+.glance-card::before,
+.panel::before,
+.detail-drawer::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.045);
+  background: var(--panel-overlay);
+  pointer-events: none;
+}
+
+.command-dock {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(320px, 1.3fr) minmax(240px, 0.9fr);
+  gap: 18px 22px;
+  align-items: start;
+  padding: 24px 24px 20px;
+  border-radius: var(--radius-xl);
+  position: relative;
+  top: auto;
+  min-height: auto;
+}
+
+.hero-band {
+  display: grid;
+  grid-template-columns: minmax(0, 1.3fr) minmax(320px, 0.92fr) minmax(180px, 0.4fr);
+  gap: 16px;
   align-items: stretch;
 }
 
-.hero-copy,
-.hero-card,
-.panel,
-.metric-card,
-.receipt-card,
+.hero-panel {
+  display: grid;
+  gap: 18px;
+  min-width: 0;
+  min-height: 100%;
+  padding: 26px 26px 22px;
+  border-radius: var(--radius-xl);
+  overflow: hidden;
+}
+
+.intro-panel {
+  align-content: space-between;
+  background:
+    radial-gradient(circle at top left, rgba(141, 182, 255, 0.18), transparent 34%),
+    radial-gradient(circle at 88% 16%, rgba(103, 244, 161, 0.08), transparent 24%),
+    linear-gradient(180deg, rgba(18, 28, 42, 0.96), rgba(9, 14, 22, 0.96));
+}
+
+.intro-panel::after {
+  content: "";
+  position: absolute;
+  inset: auto -14% -32% 26%;
+  height: 220px;
+  background: radial-gradient(circle, rgba(103, 244, 161, 0.12), transparent 72%);
+  filter: blur(22px);
+  pointer-events: none;
+}
+
+.summary-panel {
+  grid-template-rows: auto auto 1fr;
+  background:
+    radial-gradient(circle at top right, rgba(255, 190, 92, 0.08), transparent 28%),
+    linear-gradient(180deg, rgba(18, 24, 36, 0.96), rgba(9, 14, 22, 0.98));
+}
+
+.hero-actions-stack {
+  display: grid;
+  gap: 12px;
+  align-content: start;
+  align-items: start;
+  grid-auto-rows: max-content;
+}
+
+.hero-actions-stack > * {
+  width: 100%;
+  min-height: 58px;
+}
+
+.dock-brand,
+.toolbar,
+.panel-header,
+.timeline-row,
+.receipt-head,
 .history-item,
-.observer-pill {
+.observer-pill,
+.drawer-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.dock-brand {
+  align-items: flex-start;
+  gap: 14px;
+  padding-right: 8px;
+}
+
+.brand-orb {
+  position: relative;
+  flex: 0 0 50px;
+  width: 50px;
+  height: 50px;
+  border-radius: 14px;
+  border: 1px solid rgba(194, 245, 255, 0.16);
+  background:
+    linear-gradient(145deg, rgba(141, 182, 255, 0.2), rgba(255, 190, 92, 0.08)),
+    rgba(255, 255, 255, 0.05);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.1),
+    0 0 30px rgba(141, 182, 255, 0.12);
+  overflow: hidden;
+}
+
+.brand-orb span {
+  position: absolute;
+  inset: 10px;
+  border-radius: 12px;
+  border: 1px solid rgba(194, 245, 255, 0.2);
+}
+
+.brand-orb::after {
+  content: "";
+  position: absolute;
+  inset: 15px;
+  border-radius: 10px;
+  background: radial-gradient(circle, rgba(194, 245, 255, 0.68), transparent 72%);
+  animation: pulse 2.8s ease-in-out infinite;
+}
+
+.brand-copy,
+.toolbar-copy,
+.dock-note,
+.dock-meta__item,
+.panel-header > div,
+.observer-main,
+.receipt-head > div,
+.drawer-head > div {
   min-width: 0;
 }
 
 .eyebrow,
 .panel-label,
 .meta-label,
-.small-note {
-  letter-spacing: 0.12em;
+.small-note,
+.toolbar-label,
+.landing-eyebrow,
+.landing-status,
+.landing-module__label {
+  margin: 0;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
   font-size: 0.72rem;
   color: var(--muted);
 }
 
-.hero h1,
-.panel h2 {
+.brand-copy h1,
+.toolbar-copy h2,
+.panel h2,
+.panel h3,
+.detail-drawer h2 {
   margin: 0;
-  font-family: ui-serif, Georgia, Cambria, "Times New Roman", serif;
-  font-weight: 700;
   line-height: 1;
+  letter-spacing: -0.03em;
 }
 
-.hero h1 {
-  font-size: clamp(2.2rem, 5.4vw, 3.7rem);
-  max-width: 12ch;
+.brand-copy h1 {
+  font-size: clamp(1.9rem, 3vw, 2.8rem);
   text-wrap: balance;
 }
 
-.lede {
-  max-width: 52ch;
-  color: #d9e4db;
-  font-size: 1rem;
-  line-height: 1.7;
+.dock-lede,
+.toolbar-copy p,
+.session-instructions,
+.message-preview p,
+.receipt-meta,
+.history-item p,
+.drawer-body p,
+.observer-option-copy span,
+.landing-copy,
+.landing-module p {
+  color: var(--muted-strong);
+  line-height: 1.6;
 }
 
-.hero-card,
-.panel {
-  background: var(--panel);
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow);
-  backdrop-filter: blur(18px);
+.dock-lede {
+  margin: 0;
+  max-width: 54ch;
+  font-size: 0.95rem;
 }
 
-.hero-card {
-  padding: 22px;
+.dock-lede strong {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--accent-strong);
+  font-family: var(--font-mono);
+}
+
+.dock-lede strong::before {
+  content: "";
+  width: 0.62rem;
+  height: 0.62rem;
+  border-radius: 50%;
+  background: var(--good);
+  box-shadow: 0 0 14px var(--good-glow);
+  animation: pulse 2.6s ease-in-out infinite;
+}
+
+.dock-status-stack,
+.dock-meta,
+.glance-grid,
+.command-grid,
+.dashboard-grid,
+.score-grid,
+.session-meta,
+.observer-selector,
+.observer-badges,
+.history-list,
+.receipts,
+.receipt-timeline,
+.session-code-actions,
+.drawer-body,
+.drawer-stat-grid {
+  display: grid;
+  gap: 14px;
+}
+
+.dock-status-stack {
+  justify-self: stretch;
+  align-content: start;
+  gap: 12px;
+  min-width: 0;
+}
+
+.dock-note strong,
+.dock-meta__item strong {
+  color: var(--text);
+  font-size: 0.92rem;
+}
+
+.pill,
+.ghost-button,
+.primary-button,
+.panel-lens {
+  appearance: none;
+  border-radius: 999px;
+  font: inherit;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: fit-content;
+  padding: 0.72rem 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--muted-strong);
+  font-size: 0.82rem;
+}
+
+.status-pill::before {
+  content: "";
+  width: 0.66rem;
+  height: 0.66rem;
+  border-radius: 50%;
+  background: var(--poor);
+  box-shadow: 0 0 18px rgba(255, 95, 109, 0.26);
+  animation: pulse 2.4s ease-in-out infinite;
+}
+
+.status-pill.online::before {
+  background: var(--good);
+  box-shadow: 0 0 22px var(--good-glow);
+}
+
+body[data-page-mode="share"] .status-pill::before {
+  background: var(--accent);
+  box-shadow: 0 0 22px rgba(123, 214, 255, 0.24);
+}
+
+.dock-nav {
   display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  min-height: 290px;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: auto;
 }
 
-.hero-topline,
-.panel-header {
-  display: flex;
-  justify-content: space-between;
+.dock-nav__item {
+  display: inline-grid;
+  grid-template-columns: auto auto;
+  align-items: center;
+  gap: 12px;
+  padding: 11px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  text-decoration: none;
+  color: var(--muted-strong);
+  transition:
+    transform 180ms ease,
+    border-color 180ms ease,
+    background 180ms ease;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.dock-nav__item span {
+  display: inline-grid;
+  place-items: center;
+  width: 1.85rem;
+  height: 1.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.025);
+  color: var(--accent-strong);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+}
+
+.dock-nav__item strong {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.dock-nav__item:hover,
+.dock-nav__item:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(141, 182, 255, 0.14);
+  background: rgba(141, 182, 255, 0.08);
+  outline: none;
+}
+
+.dock-meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  justify-self: stretch;
+  align-self: end;
+}
+
+.dock-meta__item {
+  min-width: 154px;
+  padding: 12px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.workspace {
+  display: grid;
   gap: 16px;
+  align-content: start;
+  position: relative;
+  isolation: isolate;
+}
+
+.workspace > * {
+  position: relative;
+  z-index: 1;
+}
+
+.splash-scene {
+  position: absolute;
+  inset: -72px -56px auto;
+  height: 920px;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.splash-scene__mesh,
+.splash-scene__beam,
+.splash-scene__grid,
+.splash-scene__ring,
+.splash-scene__badge {
+  position: absolute;
+}
+
+.splash-scene__mesh {
+  inset: 44px 6% auto 4%;
+  height: 510px;
+  border-radius: 44px;
+  background:
+    radial-gradient(circle at 14% 24%, rgba(111, 140, 255, 0.34), transparent 24%),
+    radial-gradient(circle at 78% 18%, rgba(94, 217, 255, 0.18), transparent 22%),
+    radial-gradient(circle at 64% 72%, rgba(103, 244, 161, 0.18), transparent 18%),
+    linear-gradient(135deg, rgba(11, 17, 28, 0.14), rgba(11, 17, 28, 0));
+  filter: blur(12px);
+  opacity: 0.95;
+  animation: drift 22s ease-in-out infinite;
+}
+
+.splash-scene__beam {
+  top: 92px;
+  right: -88px;
+  width: 520px;
+  height: 520px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(111, 140, 255, 0.18), transparent 68%);
+  filter: blur(14px);
+}
+
+.splash-scene__grid {
+  inset: 82px 8% auto;
+  height: 460px;
+  border: 1px solid rgba(173, 196, 228, 0.08);
+  border-radius: 36px;
+  background:
+    linear-gradient(rgba(173, 196, 228, 0.06) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(173, 196, 228, 0.06) 1px, transparent 1px),
+    radial-gradient(circle at 50% 50%, rgba(141, 182, 255, 0.12), transparent 56%);
+  background-size: 88px 88px, 88px 88px, 100% 100%;
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.94), transparent 100%);
+  opacity: 0.56;
+}
+
+.splash-scene__ring {
+  border-radius: 50%;
+  border: 1px solid rgba(173, 196, 228, 0.12);
+  background: radial-gradient(circle, rgba(141, 182, 255, 0.05), transparent 70%);
+}
+
+.splash-scene__ring--left {
+  top: 152px;
+  left: -54px;
+  width: 244px;
+  height: 244px;
+}
+
+.splash-scene__ring--right {
+  top: 36px;
+  right: 8%;
+  width: 188px;
+  height: 188px;
+}
+
+.splash-scene__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.72rem 0.96rem;
+  border: 1px solid rgba(173, 196, 228, 0.12);
+  border-radius: 999px;
+  background: rgba(9, 14, 22, 0.58);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.24);
+  color: var(--muted-strong);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  backdrop-filter: blur(18px) saturate(140%);
+  -webkit-backdrop-filter: blur(18px) saturate(140%);
+}
+
+.splash-scene__badge::before {
+  content: "";
+  width: 0.52rem;
+  height: 0.52rem;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 18px rgba(141, 182, 255, 0.38);
+}
+
+.splash-scene__badge--one {
+  top: 118px;
+  right: 11%;
+}
+
+.splash-scene__badge--two {
+  top: 412px;
+  left: 9%;
+}
+
+.toolbar {
+  align-items: center;
+  padding: 20px 24px;
+  border-radius: var(--radius-xl);
+  background: rgba(15, 22, 34, 0.7);
+}
+
+.toolbar-copy h2 {
+  font-size: clamp(1.45rem, 1.8vw, 2rem);
+}
+
+.toolbar-copy p {
+  margin: 8px 0 0;
+  max-width: 62ch;
+  font-size: 0.93rem;
+}
+
+.toolbar-actions,
+.panel-actions,
+.hero-actions {
+  display: inline-flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.control-button,
+.ghost-button,
+.primary-button,
+.panel-lens {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition:
+    transform 180ms ease,
+    background 180ms ease,
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    opacity 180ms ease;
+}
+
+.ghost-button,
+.panel-lens {
+  padding: 0.74rem 0.95rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--muted-strong);
+  text-decoration: none;
+}
+
+.primary-button {
+  padding: 0.82rem 1.08rem;
+  border: 1px solid rgba(141, 182, 255, 0.16);
+  background:
+    linear-gradient(135deg, rgba(141, 182, 255, 0.2), rgba(141, 182, 255, 0.08)),
+    rgba(255, 255, 255, 0.05);
+  color: var(--accent-strong);
+  font-weight: 600;
+  text-decoration: none;
+  box-shadow: 0 10px 24px rgba(4, 10, 18, 0.24);
+}
+
+.panel-lens {
+  padding: 0.5rem 0.85rem;
+  font-size: 0.78rem;
+  color: var(--muted);
+}
+
+.ghost-button:hover,
+.primary-button:hover,
+.panel-lens:hover,
+.ghost-button:focus-visible,
+.primary-button:focus-visible,
+.panel-lens:focus-visible {
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.ghost-button:hover,
+.ghost-button:focus-visible,
+.panel-lens:hover,
+.panel-lens:focus-visible {
+  border-color: rgba(141, 182, 255, 0.14);
+  background: rgba(141, 182, 255, 0.06);
+  color: var(--text);
+}
+
+.primary-button:hover,
+.primary-button:focus-visible {
+  border-color: rgba(141, 182, 255, 0.24);
+  box-shadow: 0 14px 30px rgba(4, 10, 18, 0.3);
+}
+
+.ghost-button:disabled,
+.primary-button:disabled,
+.panel-lens:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  transform: none;
+}
+
+.glance-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.glance-card {
+  min-width: 0;
+  padding: 18px 18px 16px;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  background: rgba(16, 24, 36, 0.78);
+}
+
+[data-drawer-panel] {
+  cursor: zoom-in;
+}
+
+[data-drawer-panel] button,
+[data-drawer-panel] a,
+[data-drawer-panel] input,
+[data-drawer-panel] label {
+  cursor: pointer;
+}
+
+.glance-card:hover,
+.panel:hover {
+  border-color: rgba(123, 214, 255, 0.18);
+}
+
+.glance-card__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.glance-card__value {
+  display: block;
+  margin-top: 18px;
+  font-size: clamp(1.75rem, 2.7vw, 2.3rem);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  color: var(--text);
+}
+
+.sparkline {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(0, 1fr);
+  align-items: end;
+  gap: 6px;
+  min-height: 42px;
+  padding: 10px 0 0;
+}
+
+.sparkline-bar {
+  min-height: 6px;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(141, 182, 255, 0.7), rgba(141, 182, 255, 0.12));
+  box-shadow: none;
+  opacity: 0.7;
+  transform-origin: bottom;
+  animation: rise 420ms ease both;
+}
+
+.sparkline[data-tone="good"] .sparkline-bar {
+  background: linear-gradient(180deg, rgba(103, 244, 161, 0.9), rgba(103, 244, 161, 0.18));
+}
+
+.sparkline[data-tone="warning"] .sparkline-bar {
+  background: linear-gradient(180deg, rgba(255, 190, 92, 0.9), rgba(255, 190, 92, 0.18));
+}
+
+.sparkline[data-tone="critical"] .sparkline-bar {
+  background: linear-gradient(180deg, rgba(255, 95, 109, 0.9), rgba(255, 95, 109, 0.18));
+}
+
+.sparkline[data-tone="neutral"] .sparkline-bar {
+  background: linear-gradient(180deg, rgba(197, 208, 223, 0.42), rgba(197, 208, 223, 0.08));
+}
+
+.command-grid {
+  grid-template-columns: minmax(0, 1fr);
+  gap: 16px;
+}
+
+.dashboard-grid {
+  grid-template-columns: minmax(320px, 0.78fr) minmax(0, 1.22fr);
+  grid-template-areas:
+    "score map"
+    "observers map"
+    "reports history";
+  gap: 16px;
+  align-items: start;
+}
+
+.panel {
+  min-width: 0;
+  padding: 20px;
+  border-radius: var(--radius-xl);
+  background: rgba(15, 22, 34, 0.84);
+}
+
+.command-panel {
+  background:
+    radial-gradient(circle at top right, rgba(141, 182, 255, 0.12), transparent 22%),
+    linear-gradient(135deg, rgba(141, 182, 255, 0.08), rgba(255, 190, 92, 0.04)),
+    rgba(12, 19, 29, 0.94);
+}
+
+.hero-score-panel {
+  grid-area: score;
+  background:
+    radial-gradient(circle at top left, rgba(103, 244, 161, 0.1), transparent 26%),
+    linear-gradient(180deg, rgba(17, 24, 35, 0.95), rgba(10, 15, 24, 0.98));
+}
+
+.spotlight-panel {
+  grid-area: map;
+  background:
+    radial-gradient(circle at top left, rgba(141, 182, 255, 0.12), transparent 24%),
+    linear-gradient(180deg, rgba(14, 21, 33, 0.96), rgba(9, 14, 22, 0.98));
+}
+
+.observer-panel {
+  grid-area: observers;
+}
+
+.reports-panel {
+  grid-area: reports;
+}
+
+.history-panel {
+  grid-area: history;
+}
+
+.workspace > * {
+  min-width: 0;
+}
+
+.panel-header {
   align-items: flex-start;
   flex-wrap: wrap;
 }
@@ -115,65 +878,10 @@ body {
   align-items: center;
 }
 
-.hero-actions {
-  display: inline-flex;
-  gap: 10px;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-}
-
-.pill,
-.ghost-button {
-  border-radius: 999px;
-  border: 1px solid var(--line);
-}
-
-.pill {
-  display: inline-flex;
-  align-items: center;
-  padding: 8px 12px;
-  background: rgba(255, 255, 255, 0.04);
-  color: var(--muted);
-  font-size: 0.78rem;
-}
-
-.pill.online {
-  color: var(--good);
-  border-color: rgba(111, 217, 106, 0.35);
-}
-
-.ghost-button {
-  appearance: none;
-  background: transparent;
-  color: var(--text);
-  cursor: pointer;
-  padding: 10px 14px;
-  font-weight: 700;
-}
-
-.ghost-button:hover {
-  background: rgba(255, 255, 255, 0.05);
-}
-
-.ghost-button:disabled {
-  cursor: not-allowed;
-  opacity: 0.55;
-}
-
-.session-code {
-  margin: 18px 0 10px;
-  padding: 18px 20px;
-  border-radius: 18px;
-  background:
-    linear-gradient(135deg, rgba(230, 182, 74, 0.16), rgba(255, 255, 255, 0.03)),
-    rgba(255, 255, 255, 0.02);
-  font-family: "Courier New", monospace;
-  font-size: clamp(1.75rem, 4vw, 2.55rem);
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  line-height: 1.05;
-  overflow-wrap: anywhere;
-  word-break: break-word;
+.panel-divider {
+  height: 1px;
+  margin: 18px 0;
+  background: linear-gradient(90deg, transparent, rgba(194, 245, 255, 0.22), transparent);
 }
 
 .session-code-row {
@@ -181,80 +889,76 @@ body {
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 12px;
   align-items: stretch;
+  margin-top: 18px;
+}
+
+.session-code-block {
+  min-width: 0;
+}
+
+.session-code {
+  margin-top: 10px;
+  padding: 20px 22px;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(141, 182, 255, 0.12);
+  background:
+    linear-gradient(135deg, rgba(141, 182, 255, 0.14), rgba(141, 182, 255, 0.04)),
+    rgba(255, 255, 255, 0.03);
+  color: var(--accent-strong);
+  font-family: var(--font-mono);
+  font-size: clamp(1.7rem, 4vw, 2.7rem);
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
 
 .session-code-actions {
-  display: grid;
-  gap: 10px;
   align-content: start;
 }
 
 .copy-button {
-  margin-top: 18px;
-  min-width: 88px;
+  min-width: 96px;
 }
 
 .session-share-note {
-  margin: 0 0 12px;
+  margin: 0;
 }
 
 .session-instructions,
-.message-preview p,
-.receipt-meta,
-.receipt-path,
-.history-item p,
-.small-note {
-  color: var(--muted);
-}
-
-.session-meta,
-.score-grid {
-  display: grid;
-  gap: 12px;
+#message-preview,
+#sender-name,
+#channel-name,
+#broker-name,
+#session-status,
+#session-hash {
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .session-meta {
   grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-top: 2px;
 }
 
-.dashboard {
+.score-layout {
   display: grid;
-  grid-template-columns: repeat(12, minmax(0, 1fr));
-  gap: 18px;
-  margin-top: 24px;
-}
-
-.panel {
-  padding: 22px;
-}
-
-.panel-divider {
-  height: 1px;
-  margin: 18px 0;
-  background: var(--line);
-}
-
-.score-panel {
-  grid-column: span 7;
-}
-
-.panel:not(.score-panel):not(.wide) {
-  grid-column: span 5;
-}
-
-.panel.wide {
-  grid-column: 1 / -1;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 20px;
+  align-items: center;
+  margin-top: 16px;
 }
 
 .score-ring {
-  width: 120px;
-  height: 120px;
   position: relative;
   display: grid;
   place-items: center;
-  font-family: "Courier New", monospace;
-  font-weight: 700;
-  line-height: 1;
+  width: 132px;
+  height: 132px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.04), transparent 68%);
+  font-family: var(--font-mono);
 }
 
 .score-ring__svg {
@@ -265,51 +969,63 @@ body {
   transform: rotate(-90deg);
 }
 
-.score-ring__track {
+.score-ring__track,
+.score-ring__fill {
   fill: none;
-  stroke: rgba(255, 255, 255, 0.08);
   stroke-width: 8;
+}
+
+.score-ring__track {
+  stroke: rgba(255, 255, 255, 0.08);
 }
 
 .score-ring__fill {
-  fill: none;
-  stroke: var(--ring-color, var(--accent-strong));
-  stroke-width: 8;
+  stroke: var(--ring-color);
   stroke-linecap: round;
   stroke-dasharray: 314.16;
   stroke-dashoffset: 314.16;
-  transition: stroke-dashoffset 0.5s ease, stroke 0.4s ease;
+  filter: drop-shadow(0 0 10px rgba(194, 245, 255, 0.2));
+  transition: stroke-dashoffset 0.45s ease, stroke 0.35s ease;
 }
 
 .score-num {
-  position: relative;
-  font-size: 1.65rem;
-  color: var(--ring-color, var(--accent-strong));
-  transition: color 0.4s ease;
+  font-size: 1.7rem;
+  font-weight: 700;
+  color: var(--ring-color);
+  transition: color 0.35s ease;
 }
 
 .score-unit {
-  position: relative;
-  font-size: 0.75rem;
-  opacity: 0.7;
   vertical-align: super;
+  font-size: 0.74rem;
+  opacity: 0.76;
 }
 
 .score-grid {
-  margin-top: 20px;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .metric-card,
 .history-item,
-.receipt-card {
-  background: var(--panel-soft);
-  border: 1px solid var(--line);
-  border-radius: 18px;
+.receipt-card,
+.observer-option,
+.observer-pill,
+.empty-state,
+.drawer-card {
+  min-width: 0;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0.015)),
+    rgba(255, 255, 255, 0.02);
 }
 
 .metric-card {
   padding: 14px;
+}
+
+.metric-card.compact {
+  padding: 15px 16px;
 }
 
 .metric-label {
@@ -320,75 +1036,60 @@ body {
 }
 
 .metric-card strong,
-.receipt-title,
-.history-item strong {
+.history-item strong,
+.observer-label,
+.receipt-title {
   display: block;
-  font-size: 1.05rem;
-  line-height: 1.25;
-  overflow-wrap: anywhere;
-  word-break: break-word;
+  font-size: 1.02rem;
+  line-height: 1.28;
 }
 
 .message-preview {
   margin-top: 18px;
   padding-top: 18px;
-  border-top: 1px solid var(--line);
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 #message-preview {
-  margin: 8px 0 0;
-  max-height: 5.8em;
+  margin: 10px 0 0;
+  max-height: 6.1em;
   overflow: auto;
   padding-right: 6px;
   font-size: 0.94rem;
-  line-height: 1.45;
   white-space: pre-wrap;
 }
 
-.observer-selector,
-.observer-badges,
-.history-list,
-.receipts {
+.observer-panel {
   display: grid;
-  gap: 12px;
+  align-content: start;
 }
 
 .observer-selector {
-  max-height: 280px;
-  margin-top: 14px;
+  max-height: 320px;
   overflow: auto;
-  padding-right: 4px;
+  padding-right: 2px;
 }
 
 .observer-badges {
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  margin-top: 18px;
-}
-
-.allowlist-note {
-  margin-top: 12px;
 }
 
 .observer-option {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
-  align-items: start;
   gap: 12px;
-  padding: 12px 14px;
-  border-radius: 18px;
-  border: 1px solid var(--line);
-  background: rgba(255, 255, 255, 0.03);
-  cursor: pointer;
+  align-items: start;
+  padding: 14px 16px;
 }
 
 .observer-option input {
   margin-top: 2px;
+  accent-color: var(--accent);
 }
 
 .observer-option-copy {
   display: grid;
   gap: 4px;
-  min-width: 0;
 }
 
 .observer-option-copy strong,
@@ -397,107 +1098,230 @@ body {
   word-break: break-word;
 }
 
-.observer-option-copy span {
-  color: var(--muted);
-  font-size: 0.84rem;
-}
-
 .observer-option.active {
-  border-color: rgba(111, 217, 106, 0.24);
+  border-color: rgba(141, 182, 255, 0.14);
 }
 
 .observer-option.inactive {
-  opacity: 0.76;
+  opacity: 0.78;
 }
 
 .observer-pill {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  align-items: flex-start;
   gap: 12px;
+  align-items: center;
   padding: 14px 16px;
-  border-radius: 18px;
-  border: 1px solid var(--line);
-  background: rgba(255, 255, 255, 0.03);
 }
 
-.observer-pill > div,
-.history-item > div,
-.receipt-head > div,
-.panel-header > div {
-  min-width: 0;
+.observer-pill .status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.035);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
-.observer-pill strong,
-.observer-pill .small-note,
-.history-item p,
-.history-item .history-code,
-.session-instructions,
-#session-status,
-#session-hash,
-#sender-name,
-#channel-name,
-#broker-name,
-#message-preview {
+.observer-pill .status::before {
+  content: "";
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 12px currentColor;
+}
+
+.observer-pill.seen {
+  border-color: rgba(103, 244, 161, 0.14);
+  background:
+    linear-gradient(180deg, rgba(103, 244, 161, 0.08), rgba(103, 244, 161, 0.02)),
+    rgba(255, 255, 255, 0.03);
+}
+
+.observer-pill.seen .status {
+  color: var(--good);
+}
+
+.observer-pill.waiting .status {
+  color: var(--fair);
+}
+
+.observer-hash,
+.receipt-hash,
+.history-code,
+.drawer-mono,
+.console-line code,
+.receipt-path,
+.dock-nav__item span {
+  font-family: var(--font-mono);
+}
+
+.observer-hash,
+.receipt-hash {
+  color: var(--muted);
+  font-size: 0.8rem;
   overflow-wrap: anywhere;
   word-break: break-word;
 }
 
-.hash-link {
-  color: var(--accent);
-  text-decoration: none;
-  text-underline-offset: 0.18em;
+.map-panel,
+.reports-panel {
+  min-height: 0;
 }
 
-.hash-link:hover {
-  color: var(--accent-strong);
-  text-decoration: underline;
+.map-panel {
+  display: grid;
+  align-content: start;
 }
 
-.hash-link.pending {
-  color: inherit;
-  pointer-events: none;
-  text-decoration: none;
+.observer-map {
+  min-height: 450px;
+  margin-top: 12px;
+  overflow: hidden;
+  border-radius: calc(var(--radius-lg) + 2px);
+  border: 1px solid rgba(255, 255, 255, 0.06);
 }
 
-.observer-main {
+.spotlight-panel .observer-map {
+  min-height: 560px;
+}
+
+.observer-map.hidden {
+  display: none;
+}
+
+.leaflet-container {
+  background: radial-gradient(circle, rgba(7, 17, 29, 0.98), rgba(5, 11, 18, 0.98));
+  color: var(--text);
+  font-family: var(--font-sans);
+}
+
+.leaflet-control-zoom a,
+.leaflet-control-attribution {
+  border: 1px solid rgba(194, 245, 255, 0.12) !important;
+  background: rgba(7, 17, 29, 0.82) !important;
+  color: var(--text) !important;
+}
+
+.leaflet-popup-content-wrapper,
+.leaflet-popup-tip {
+  background: rgba(8, 19, 34, 0.92);
+  color: var(--text);
+  border: 1px solid rgba(194, 245, 255, 0.12);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.32);
+}
+
+.observer-map-icon-shell {
+  background: transparent !important;
+  border: 0 !important;
+}
+
+.observer-map-icon {
+  position: relative;
+  display: block;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.8);
+  background: var(--fair);
+  box-shadow: 0 0 16px rgba(255, 190, 92, 0.34);
+}
+
+.observer-map-icon::after {
+  content: "";
+  position: absolute;
+  inset: -8px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  opacity: 0.6;
+  animation: pulseRing 2.6s ease-out infinite;
+}
+
+.observer-map-icon.seen {
+  background: var(--good);
+  box-shadow: 0 0 16px rgba(103, 244, 161, 0.36);
+}
+
+.timeline-block {
+  display: grid;
+  gap: 14px;
+}
+
+.timeline-scale {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  font-family: var(--font-mono);
+  color: var(--muted);
+  font-size: 0.76rem;
+}
+
+.receipt-timeline {
+  gap: 12px;
+}
+
+.timeline-row {
+  align-items: center;
+  padding: 12px 14px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.timeline-copy {
+  display: grid;
+  gap: 4px;
   min-width: 0;
 }
 
-.observer-label {
-  display: block;
-  font-size: 0.96rem;
-  line-height: 1.35;
+.timeline-copy strong,
+.timeline-copy span {
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
-.observer-hash {
-  margin-top: 4px;
+.timeline-copy span {
+  color: var(--muted);
+  font-size: 0.82rem;
 }
 
-.observer-pill.seen {
-  border-color: rgba(111, 217, 106, 0.32);
-  background: rgba(111, 217, 106, 0.08);
-}
-
-.observer-pill.waiting {
-  border-color: rgba(255, 255, 255, 0.1);
-}
-
-.observer-pill .status {
-  align-self: center;
-  white-space: nowrap;
-  font-family: "Courier New", monospace;
-  font-size: 0.74rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  padding: 5px 9px;
+.timeline-track {
+  position: relative;
+  flex: 1 1 240px;
+  height: 0.82rem;
   border-radius: 999px;
-  background: rgba(0, 0, 0, 0.2);
+  background: rgba(255, 255, 255, 0.05);
+  overflow: hidden;
+}
+
+.timeline-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  border-radius: inherit;
+  background: linear-gradient(90deg, rgba(123, 214, 255, 0.34), rgba(123, 214, 255, 0.12));
+}
+
+.timeline-dot {
+  position: absolute;
+  top: 50%;
+  width: 0.92rem;
+  height: 0.92rem;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.88);
+  background: var(--accent);
+  box-shadow: 0 0 20px rgba(123, 214, 255, 0.28);
+  transform: translate(-50%, -50%);
 }
 
 .receipts {
-  grid-template-columns: repeat(auto-fit, minmax(255px, 1fr));
-  margin-top: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  margin-top: 16px;
 }
 
 .receipt-card,
@@ -505,10 +1329,24 @@ body {
   padding: 16px;
 }
 
+.receipt-card {
+  cursor: pointer;
+  transition:
+    transform 180ms ease,
+    border-color 180ms ease,
+    background 180ms ease;
+}
+
+.receipt-card:hover,
+.history-item:hover {
+  transform: translateY(-2px);
+  border-color: rgba(141, 182, 255, 0.12);
+  background:
+    linear-gradient(180deg, rgba(141, 182, 255, 0.06), rgba(255, 255, 255, 0.02)),
+    rgba(255, 255, 255, 0.03);
+}
+
 .receipt-head {
-  display: flex;
-  justify-content: space-between;
-  gap: 12px;
   align-items: flex-start;
   flex-wrap: wrap;
 }
@@ -517,167 +1355,126 @@ body {
   margin: 0;
 }
 
-.receipt-hash {
-  font-family: "Courier New", monospace;
-  color: var(--accent);
-  font-size: 0.8rem;
-  overflow-wrap: anywhere;
-  word-break: break-word;
+.receipt-meta {
+  margin: 12px 0 0;
+}
+
+.receipt-meter-grid {
+  display: grid;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.receipt-meter {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.82rem;
+  color: var(--muted-strong);
+}
+
+.meter-track {
+  position: relative;
+  height: 0.52rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  overflow: hidden;
+}
+
+.meter-track span {
+  position: absolute;
+  inset: 0 auto 0 0;
+  border-radius: inherit;
+  background: linear-gradient(90deg, rgba(123, 214, 255, 0.92), rgba(103, 244, 161, 0.78));
+}
+
+.meter-track.warning span {
+  background: linear-gradient(90deg, rgba(255, 190, 92, 0.92), rgba(255, 145, 69, 0.78));
+}
+
+.meter-track.critical span {
+  background: linear-gradient(90deg, rgba(255, 95, 109, 0.95), rgba(255, 110, 149, 0.78));
 }
 
 .receipt-path {
-  margin: 12px 0 0;
-  padding: 12px;
-  border-radius: 14px;
-  background: rgba(0, 0, 0, 0.22);
-  font-family: "Courier New", monospace;
-  font-size: 0.82rem;
-  line-height: 1.5;
-  word-break: break-word;
-}
-
-.timeline-block {
-  margin-top: 18px;
-  padding: 18px;
-  border: 1px solid var(--line);
-  border-radius: 20px;
-  background: rgba(255, 255, 255, 0.03);
-}
-
-.timeline-block h3 {
-  margin: 0;
-  font-family: ui-serif, Georgia, Cambria, "Times New Roman", serif;
-  font-size: 1.15rem;
-  line-height: 1.1;
-}
-
-.timeline-scale {
   display: flex;
-  justify-content: space-between;
-  gap: 16px;
-  margin-top: 14px;
-  color: var(--muted);
-  font-size: 0.72rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
 }
 
-.receipt-timeline {
-  display: grid;
-  gap: 14px;
-  margin-top: 14px;
+.receipt-path span {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.46rem 0.66rem;
+  border-radius: 999px;
+  border: 1px solid rgba(194, 245, 255, 0.12);
+  background: rgba(194, 245, 255, 0.05);
+  color: var(--accent-strong);
+  font-size: 0.74rem;
 }
 
-.timeline-row {
+.history-list {
+  margin-top: 4px;
+}
+
+.history-item {
   display: grid;
-  grid-template-columns: minmax(0, 230px) minmax(0, 1fr);
-  gap: 16px;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
 }
 
-.timeline-copy strong,
-.timeline-copy span {
-  display: block;
-}
-
-.timeline-copy strong {
-  font-size: 0.95rem;
-}
-
-.timeline-copy span {
-  margin-top: 4px;
-  color: var(--muted);
-  font-size: 0.82rem;
-}
-
-.timeline-track {
-  position: relative;
-  height: 10px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
-  overflow: visible;
-}
-
-.timeline-fill {
-  display: block;
-  height: 100%;
-  border-radius: inherit;
-  background: linear-gradient(90deg, rgba(230, 182, 74, 0.35), rgba(230, 182, 74, 0.8));
-}
-
-.timeline-dot {
-  position: absolute;
-  top: 50%;
-  width: 16px;
-  height: 16px;
-  border-radius: 50%;
-  background: var(--accent-strong);
-  border: 3px solid rgba(16, 21, 18, 0.96);
-  box-shadow: 0 0 0 2px rgba(230, 182, 74, 0.18);
-  transform: translate(-50%, -50%);
-}
-
-.observer-map {
-  margin-top: 16px;
-  height: 360px;
-  border-radius: 20px;
-  overflow: hidden;
-  border: 1px solid var(--line);
-}
-
-.observer-map .leaflet-control-attribution,
-.observer-map .leaflet-popup-content-wrapper,
-.observer-map .leaflet-popup-tip {
-  background: rgba(17, 23, 20, 0.96);
-  color: var(--text);
-}
-
-.observer-map .leaflet-control-attribution {
-  color: var(--muted);
-}
-
-.observer-map-icon-shell {
-  background: transparent;
-  border: 0;
-}
-
-.observer-map-icon {
-  display: block;
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  border: 3px solid rgba(11, 15, 12, 0.92);
-  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.12);
-}
-
-.observer-map-icon.seen {
-  background: var(--good);
-}
-
-.observer-map-icon.missed {
-  background: var(--poor);
+.history-code {
+  font-size: 0.86rem;
+  color: var(--accent-strong);
 }
 
 .empty-state {
-  margin-top: 18px;
-  padding: 18px;
-  border: 1px dashed rgba(255, 255, 255, 0.14);
-  border-radius: 18px;
-  color: var(--muted);
+  padding: 20px;
+  color: var(--muted-strong);
 }
 
 .empty-state.compact {
-  margin-top: 0;
-  padding: 14px;
+  padding: 16px;
 }
 
-.hidden {
-  display: none !important;
+.hash-link {
+  color: var(--accent-strong);
+  text-decoration: none;
+  text-underline-offset: 0.2em;
+}
+
+.hash-link:hover,
+.hash-link:focus-visible {
+  color: #fff;
+  text-decoration: underline;
+  outline: none;
+}
+
+.hash-link.pending {
+  color: var(--muted-strong);
+  pointer-events: none;
+  text-decoration: none;
+}
+
+.status-good {
+  color: var(--good);
+  text-shadow: 0 0 18px rgba(103, 244, 161, 0.18);
+}
+
+.status-fair {
+  color: var(--fair);
+  text-shadow: 0 0 18px rgba(255, 190, 92, 0.14);
+}
+
+.status-poor {
+  color: var(--poor);
+  text-shadow: 0 0 18px rgba(255, 95, 109, 0.16);
 }
 
 .site-footer {
-  margin-top: 22px;
-  padding: 0 4px;
+  padding: 4px 4px 0;
 }
 
 .site-footer p {
@@ -685,107 +1482,1442 @@ body {
 }
 
 .site-footer a {
-  color: var(--accent);
+  color: var(--accent-strong);
   text-decoration: none;
 }
 
-.site-footer a:hover {
-  color: var(--accent-strong);
+.site-footer a:hover,
+.site-footer a:focus-visible {
   text-decoration: underline;
+  outline: none;
+}
+
+.drawer-scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(3, 8, 14, 0.48);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 220ms ease;
+  z-index: 39;
+}
+
+.detail-drawer {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  bottom: 20px;
+  width: min(460px, calc(100vw - 24px));
+  padding: 22px;
+  border-radius: 26px;
+  overflow: auto;
+  transform: translateX(calc(100% + 24px));
+  opacity: 0;
+  transition:
+    transform 240ms ease,
+    opacity 240ms ease;
+  z-index: 40;
+}
+
+.drawer-head {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  align-items: flex-start;
+  padding-bottom: 16px;
+  margin-bottom: 18px;
+  background: linear-gradient(180deg, rgba(8, 19, 34, 0.96), rgba(8, 19, 34, 0.78), transparent);
+}
+
+.drawer-body {
+  align-content: start;
+}
+
+.drawer-card {
+  padding: 16px;
+}
+
+.drawer-card h3 {
+  margin: 0 0 12px;
+  font-size: 1rem;
+}
+
+.drawer-stat-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.drawer-stat {
+  padding: 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.drawer-stat strong {
+  display: block;
+  margin-top: 6px;
+  font-size: 1rem;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.drawer-list,
+.console-lines {
+  display: grid;
+  gap: 10px;
+}
+
+.drawer-list__item,
+.console-line {
+  padding: 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.drawer-list__item strong,
+.console-line strong {
+  display: block;
+  margin-bottom: 6px;
+}
+
+.console-line {
+  display: grid;
+  gap: 6px;
+  font-size: 0.88rem;
+}
+
+.console-line code {
+  width: fit-content;
+}
+
+.drawer-codeblock {
+  margin: 0;
+  padding: 14px;
+  overflow: auto;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  background: rgba(5, 11, 18, 0.76);
+  color: var(--accent-strong);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  line-height: 1.7;
+  white-space: pre-wrap;
+}
+
+body.drawer-open {
+  overflow: hidden;
+}
+
+body.drawer-open .drawer-scrim {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+body.drawer-open .detail-drawer {
+  transform: translateX(0);
+  opacity: 1;
 }
 
 body[data-page-mode="share"] .share-hidden {
   display: none !important;
 }
 
-body[data-page-mode="share"] .share-hero-card {
-  min-height: 0;
+@keyframes pulse {
+  0%,
+  100% {
+    transform: scale(0.96);
+    opacity: 0.72;
+  }
+  50% {
+    transform: scale(1.06);
+    opacity: 1;
+  }
 }
 
-.history-list {
-  margin-top: 18px;
+@keyframes pulseRing {
+  0% {
+    transform: scale(0.86);
+    opacity: 0.85;
+  }
+  100% {
+    transform: scale(1.2);
+    opacity: 0;
+  }
 }
 
-.history-item {
-  display: flex;
-  justify-content: space-between;
-  gap: 16px;
-  align-items: center;
-  flex-wrap: wrap;
+@keyframes drift {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0);
+  }
+  50% {
+    transform: translate3d(-18px, -12px, 0);
+  }
 }
 
-.history-item .history-code {
-  font-family: "Courier New", monospace;
-  color: var(--accent);
+@keyframes rise {
+  from {
+    transform: scaleY(0.25);
+    opacity: 0;
+  }
+  to {
+    transform: scaleY(1);
+    opacity: 0.95;
+  }
 }
 
-.status-good {
-  color: var(--good);
-}
-
-.status-fair {
-  color: var(--fair);
-}
-
-.status-poor {
-  color: var(--poor);
-}
-
-@media (max-width: 960px) {
-  .hero {
-    grid-template-columns: 1fr;
+@media (max-width: 1320px) {
+  .noc-shell {
+    width: min(1280px, calc(100vw - 28px));
   }
 
-  .score-panel,
-  .panel:not(.score-panel):not(.wide),
-  .panel.wide {
+  .hero-band {
+    grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
+  }
+
+  .hero-actions-stack {
     grid-column: 1 / -1;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
-  .score-grid {
+  .glance-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .timeline-row {
-    grid-template-columns: 1fr;
-    gap: 10px;
+  .dashboard-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
-@media (max-width: 640px) {
-  .shell {
-    width: min(100vw - 20px, 100%);
-    padding-top: 18px;
+@media (max-width: 980px) {
+  .noc-shell {
+    width: min(1100px, calc(100vw - 24px));
+    padding-top: 16px;
   }
 
-  .hero-card,
-  .panel {
-    padding: 18px;
-  }
-
-  .score-grid,
-  .session-meta,
-  .session-code-row {
+  .hero-band {
     grid-template-columns: 1fr;
+    gap: 14px;
+  }
+
+  .hero-actions-stack {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .dock-status-stack,
+  .dock-meta {
+    justify-self: stretch;
+  }
+
+  .command-grid,
+  .dashboard-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .dashboard-grid {
+    grid-template-areas:
+      "score"
+      "map"
+      "observers"
+      "reports"
+      "history";
+  }
+
+  .spotlight-panel .observer-map {
+    min-height: 420px;
+  }
+}
+
+@media (max-width: 720px) {
+  .noc-shell {
+    width: min(100vw - 16px, 100%);
+    gap: 16px;
+    padding-bottom: 28px;
+  }
+
+  .hero-panel,
+  .panel {
+    border-radius: 22px;
+  }
+
+  .hero-band {
+    gap: 14px;
+  }
+
+  .hero-panel {
+    gap: 14px;
+    padding: 16px;
+  }
+
+  .dock-brand {
+    gap: 12px;
+    align-items: start;
+  }
+
+  .brand-orb {
+    flex-basis: 46px;
+    width: 46px;
+    height: 46px;
+    border-radius: 14px;
+  }
+
+  .brand-orb span {
+    inset: 8px;
+    border-radius: 9px;
+  }
+
+  .brand-copy h1 {
+    font-size: clamp(1.4rem, 8vw, 1.9rem);
+  }
+
+  .dock-lede {
+    margin: 0;
+    font-size: 0.9rem;
+    line-height: 1.45;
+  }
+
+  .dock-meta {
+    display: none;
+  }
+
+  .dock-nav {
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: max-content;
+    gap: 8px;
+    padding-bottom: 2px;
+    margin: 0 -2px;
+    padding-left: 2px;
+    padding-right: 2px;
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    scrollbar-width: none;
+  }
+
+  .dock-nav::-webkit-scrollbar,
+  .glance-grid::-webkit-scrollbar {
+    display: none;
+  }
+
+  .dock-nav__item {
+    grid-template-columns: auto auto;
+    gap: 10px;
+    min-width: max-content;
+    padding: 10px 12px;
+    white-space: nowrap;
+  }
+
+  .dock-nav__item strong {
+    font-size: 0.88rem;
+  }
+
+  .hero-actions-stack {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-actions-stack > * {
+    width: 100%;
+  }
+
+  .toolbar-copy h2 {
+    font-size: 1.35rem;
+  }
+
+  .toolbar-copy p {
+    margin-top: 8px;
+    font-size: 0.9rem;
+    line-height: 1.45;
+  }
+
+  .workspace {
+    gap: 14px;
+  }
+
+  .hero-band {
+    order: 0;
+  }
+
+  .command-grid {
+    order: 1;
+  }
+
+  .glance-grid {
+    order: 2;
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(82%, 1fr);
+    grid-template-columns: none;
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    padding-bottom: 4px;
+    scroll-snap-type: x proximity;
+  }
+
+  .glance-card {
+    scroll-snap-align: start;
+    padding: 16px;
+  }
+
+  .dashboard-grid {
+    order: 3;
+    grid-template-areas:
+      "score"
+      "map"
+      "observers"
+      "reports"
+      "history";
+  }
+
+  .site-footer {
+    order: 4;
+  }
+
+  .glance-card__value {
+    margin-top: 16px;
+    font-size: 1.7rem;
+  }
+
+  .panel {
+    padding: 16px;
+  }
+
+  .session-code-row,
+  .score-layout,
+  .history-item,
+  .timeline-row {
+    grid-template-columns: 1fr;
+    display: grid;
+  }
+
+  .score-layout {
+    justify-items: start;
+  }
+
+  .session-code {
+    font-size: clamp(1.45rem, 9vw, 2rem);
+    padding: 18px 16px;
   }
 
   .session-code-actions {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .score-ring {
-    width: 88px;
-    height: 88px;
-    font-size: 1.1rem;
+  .session-code-actions > * {
+    width: 100%;
   }
 
-  .hero-topline,
-  .panel-header {
-    gap: 12px;
+  .session-meta,
+  .drawer-stat-grid,
+  .score-grid {
+    grid-template-columns: 1fr;
   }
 
-  .history-item {
-    flex-direction: column;
-    align-items: flex-start;
+  .observer-badges,
+  .receipts {
+    grid-template-columns: 1fr;
+  }
+
+  .observer-map {
+    min-height: 320px;
+  }
+
+  .timeline-track {
+    min-width: 0;
+  }
+
+  .detail-drawer {
+    top: 8px;
+    right: 8px;
+    left: 8px;
+    bottom: 8px;
+    width: auto;
+    border-radius: 22px;
+    max-height: calc(100dvh - 16px);
+  }
+}
+
+/* Dynamic editorial overrides */
+
+.hero-stage {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1.18fr) minmax(320px, 0.82fr) minmax(132px, 0.28fr);
+  gap: 0;
+  overflow: hidden;
+  border: 1px solid rgba(173, 196, 228, 0.14);
+  border-radius: 30px;
+  background:
+    radial-gradient(circle at 0% 0%, rgba(103, 244, 161, 0.12), transparent 24%),
+    radial-gradient(circle at 88% 10%, rgba(141, 182, 255, 0.2), transparent 22%),
+    linear-gradient(135deg, rgba(11, 17, 28, 0.98), rgba(14, 19, 30, 0.94) 48%, rgba(8, 13, 21, 0.98));
+  box-shadow: 0 36px 110px rgba(0, 0, 0, 0.34);
+}
+
+.hero-stage::before,
+.hero-stage::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.hero-stage::before {
+  background:
+    linear-gradient(125deg, rgba(255, 255, 255, 0.02), transparent 28%),
+    repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.025) 0 1px, transparent 1px 96px);
+  opacity: 0.5;
+}
+
+.hero-stage::after {
+  inset: auto -10% -40% 38%;
+  height: 260px;
+  background: radial-gradient(circle, rgba(255, 190, 92, 0.16), transparent 72%);
+  filter: blur(28px);
+}
+
+.hero-stage > * {
+  position: relative;
+  z-index: 1;
+}
+
+.hero-stage .hero-panel,
+.hero-stage .telemetry-strip,
+.hero-stage__action-rail {
+  background: transparent;
+  box-shadow: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
+
+.hero-stage .hero-panel,
+.hero-stage .telemetry-strip__item {
+  border: 0;
+}
+
+.hero-stage .hero-panel::before,
+.hero-stage .telemetry-strip__item::before {
+  display: none;
+}
+
+.hero-stage__lead,
+.hero-stage__brief {
+  min-width: 0;
+  min-height: 100%;
+  padding: 30px 28px 24px;
+}
+
+.hero-stage__lead {
+  display: grid;
+  gap: 18px;
+  align-content: start;
+}
+
+.hero-stage__brief {
+  display: grid;
+  gap: 18px;
+  align-content: start;
+  border-left: 1px solid rgba(173, 196, 228, 0.1);
+  border-right: 1px solid rgba(173, 196, 228, 0.1);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.025), transparent 70%);
+}
+
+.hero-stage__lead .brand-copy h1 {
+  font-size: clamp(2.25rem, 4vw, 4.2rem);
+  line-height: 0.94;
+}
+
+.hero-stage__lead .dock-lede {
+  max-width: 62ch;
+  font-size: 0.98rem;
+}
+
+.hero-stage__pulse {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 12px;
+  align-items: start;
+  max-width: 38rem;
+}
+
+.hero-stage__pulse-dot {
+  width: 0.78rem;
+  height: 0.78rem;
+  margin-top: 0.34rem;
+  border-radius: 50%;
+  background: var(--good);
+  box-shadow: 0 0 18px var(--good-glow);
+  animation: pulse 2.4s ease-in-out infinite;
+}
+
+.hero-stage__pulse .small-note {
+  margin-top: 4px;
+}
+
+.hero-stage__meta-strip {
+  grid-template-columns: 1fr;
+  gap: 12px;
+}
+
+.hero-stage__meta-strip .dock-meta__item {
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  border-left: 2px solid rgba(141, 182, 255, 0.18);
+  border-radius: 0;
+  background: transparent;
+  padding-left: 14px;
+}
+
+.hero-stage__action-rail {
+  display: grid;
+  gap: 12px;
+  align-content: start;
+  padding: 20px 18px;
+}
+
+.hero-stage__action-rail > * {
+  width: 100%;
+  min-height: 58px;
+  border-radius: 20px;
+}
+
+.action-menu {
+  position: relative;
+  width: 100%;
+}
+
+.action-menu__button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  list-style: none;
+  cursor: pointer;
+}
+
+.action-menu__button::-webkit-details-marker {
+  display: none;
+}
+
+.action-menu__button::after {
+  content: "▾";
+  font-size: 0.85rem;
+  opacity: 0.72;
+  transition: transform 180ms ease;
+}
+
+.action-menu[open] .action-menu__button::after {
+  transform: rotate(180deg);
+}
+
+.action-menu__panel {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  z-index: 12;
+  display: grid;
+  gap: 8px;
+  width: min(248px, calc(100vw - 32px));
+  padding: 10px;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: var(--panel-strong);
+  box-shadow: 0 20px 56px rgba(0, 0, 0, 0.24);
+  backdrop-filter: blur(24px) saturate(140%);
+  -webkit-backdrop-filter: blur(24px) saturate(140%);
+}
+
+.action-menu:not([open]) .action-menu__panel {
+  display: none;
+}
+
+.action-menu__item {
+  width: 100%;
+  justify-content: flex-start;
+}
+
+.telemetry-strip {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0;
+  border-top: 1px solid rgba(173, 196, 228, 0.12);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.025), rgba(255, 255, 255, 0.01));
+}
+
+.telemetry-strip__item {
+  min-width: 0;
+  padding: 18px 22px 20px;
+  border-right: 1px solid rgba(173, 196, 228, 0.12);
+  border-radius: 0;
+  overflow: hidden;
+}
+
+.telemetry-strip__item:last-child {
+  border-right: 0;
+}
+
+.telemetry-strip .glance-card__value {
+  margin-top: 14px;
+  font-size: clamp(2rem, 3vw, 3.1rem);
+}
+
+.telemetry-strip .sparkline {
+  max-width: 220px;
+}
+
+.telemetry-strip .panel-lens {
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+
+.marquee-panel {
+  overflow: hidden;
+  padding: 24px 26px;
+  background:
+    radial-gradient(circle at top right, rgba(141, 182, 255, 0.18), transparent 22%),
+    radial-gradient(circle at 12% 88%, rgba(103, 244, 161, 0.08), transparent 18%),
+    linear-gradient(135deg, rgba(19, 27, 40, 0.98), rgba(11, 16, 26, 0.96));
+}
+
+.marquee-panel::after {
+  content: "";
+  position: absolute;
+  inset: auto -8% -36% 44%;
+  height: 240px;
+  background: radial-gradient(circle, rgba(141, 182, 255, 0.14), transparent 70%);
+  filter: blur(28px);
+  pointer-events: none;
+}
+
+.marquee-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.14fr) minmax(320px, 0.86fr);
+  gap: 24px;
+  align-items: start;
+  margin-top: 18px;
+}
+
+.session-sequence {
+  display: grid;
+  gap: 14px;
+  min-width: 0;
+}
+
+.health-pocket {
+  min-width: 0;
+  padding-left: 24px;
+  border-left: 1px solid rgba(173, 196, 228, 0.12);
+}
+
+.health-pocket__head {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  align-items: start;
+}
+
+.health-pocket__head h2 {
+  margin: 2px 0 0;
+  font-size: clamp(1.7rem, 2.8vw, 2.8rem);
+  line-height: 0.95;
+}
+
+.health-pocket__content {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 18px;
+  align-items: center;
+  margin-top: 16px;
+}
+
+.health-pocket__stats {
+  gap: 12px;
+}
+
+.marquee-panel .session-meta .metric-card,
+.health-pocket .metric-card {
+  padding: 12px 0;
+  border-radius: 0;
+  border-width: 0 0 1px;
+  border-color: rgba(173, 196, 228, 0.12);
+  background: transparent;
+}
+
+.marquee-panel .session-meta .metric-card:last-child,
+.health-pocket .metric-card:nth-last-child(-n + 2) {
+  border-bottom: 0;
+}
+
+.marquee-panel .message-preview {
+  margin-top: 20px;
+  padding-top: 18px;
+  border-top: 1px solid rgba(173, 196, 228, 0.12);
+}
+
+.dashboard-grid {
+  grid-template-columns: minmax(0, 1.26fr) minmax(300px, 0.74fr);
+  grid-template-areas:
+    "map observers"
+    "ledger observers";
+  align-items: stretch;
+}
+
+.spotlight-panel {
+  grid-area: map;
+  padding: 18px 18px 20px;
+  background:
+    radial-gradient(circle at top left, rgba(141, 182, 255, 0.18), transparent 24%),
+    radial-gradient(circle at 82% 18%, rgba(103, 244, 161, 0.08), transparent 16%),
+    linear-gradient(180deg, rgba(15, 23, 36, 0.98), rgba(8, 13, 21, 0.98));
+}
+
+.spotlight-panel .observer-map {
+  min-height: 560px;
+  margin-top: 14px;
+  border-radius: 24px;
+}
+
+.observer-panel {
+  grid-area: observers;
+  align-self: stretch;
+  min-height: 100%;
+  background:
+    radial-gradient(circle at 84% 12%, rgba(94, 217, 255, 0.08), transparent 20%),
+    linear-gradient(180deg, rgba(18, 24, 36, 0.96), rgba(10, 15, 24, 0.98));
+}
+
+.ledger-panel {
+  grid-area: ledger;
+  background:
+    radial-gradient(circle at top right, rgba(255, 190, 92, 0.12), transparent 24%),
+    radial-gradient(circle at 12% 88%, rgba(141, 182, 255, 0.08), transparent 18%),
+    linear-gradient(180deg, rgba(18, 25, 37, 0.98), rgba(10, 15, 24, 0.98));
+}
+
+.ledger-divider {
+  height: 1px;
+  margin: 24px 0 20px;
+  background: linear-gradient(90deg, transparent, rgba(173, 196, 228, 0.24), transparent);
+}
+
+.ledger-panel .receipts,
+.ledger-panel .history-list {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.ledger-panel .history-list {
+  margin-top: 0;
+}
+
+.ledger-history-head {
+  margin-bottom: 12px;
+}
+
+body[data-page-mode="share"] .ledger-panel .history-list {
+  display: none;
+}
+
+@media (max-width: 1240px) {
+  .splash-scene {
+    inset: -56px -26px auto;
+    height: 780px;
+  }
+
+  .splash-scene__badge--one {
+    right: 7%;
+  }
+
+  .splash-scene__badge--two {
+    left: 6%;
+  }
+
+  .hero-stage {
+    grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+  }
+
+  .hero-stage__brief {
+    border-right: 0;
+  }
+
+  .hero-stage__action-rail {
+    grid-column: 1 / -1;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    padding-top: 16px;
+    border-top: 1px solid rgba(173, 196, 228, 0.12);
+  }
+
+  .telemetry-strip {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .telemetry-strip__item {
+    border-right: 1px solid rgba(173, 196, 228, 0.12);
+    border-top: 1px solid rgba(173, 196, 228, 0.12);
+  }
+
+  .telemetry-strip__item:nth-child(2n) {
+    border-right: 0;
+  }
+
+  .telemetry-strip__item:nth-child(-n + 2) {
+    border-top: 0;
+  }
+
+  .marquee-layout,
+  .dashboard-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .health-pocket {
+    padding-left: 0;
+    padding-top: 20px;
+    border-left: 0;
+    border-top: 1px solid rgba(173, 196, 228, 0.12);
+  }
+
+  .dashboard-grid {
+    grid-template-areas:
+      "map"
+      "observers"
+      "ledger";
+  }
+
+  .spotlight-panel .observer-map {
+    min-height: 440px;
+  }
+}
+
+@media (max-width: 720px) {
+  .splash-scene {
+    inset: -36px -18px auto;
+    height: 430px;
+  }
+
+  .splash-scene__mesh {
+    inset: 26px 0 auto;
+    height: 250px;
+    border-radius: 28px;
+    filter: blur(10px);
+  }
+
+  .splash-scene__beam {
+    top: 26px;
+    right: -94px;
+    width: 260px;
+    height: 260px;
+  }
+
+  .splash-scene__grid {
+    inset: 40px 8px auto;
+    height: 220px;
+    background-size: 48px 48px, 48px 48px, 100% 100%;
+    opacity: 0.42;
+  }
+
+  .splash-scene__ring,
+  .splash-scene__badge {
+    display: none;
+  }
+
+  .hero-stage {
+    grid-template-columns: 1fr;
+    border-radius: 24px;
+  }
+
+  .hero-stage__lead,
+  .hero-stage__brief {
+    padding: 18px 16px;
+  }
+
+  .hero-stage__brief {
+    border-left: 0;
+    border-right: 0;
+    border-top: 1px solid rgba(173, 196, 228, 0.12);
+  }
+
+  .hero-stage__lead .brand-copy h1 {
+    font-size: clamp(1.6rem, 8vw, 2.35rem);
+  }
+
+  .hero-stage__action-rail {
+    grid-template-columns: 1fr;
+    padding: 12px 16px 18px;
+  }
+
+  .action-menu__panel {
+    top: auto;
+    bottom: calc(100% + 10px);
+    width: 100%;
+  }
+
+  .telemetry-strip {
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(82%, 1fr);
+    grid-template-columns: none;
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    scrollbar-width: none;
+  }
+
+  .telemetry-strip__item {
+    border-right: 1px solid rgba(173, 196, 228, 0.12);
+    border-top: 0;
+  }
+
+  .marquee-panel {
+    padding: 16px;
+  }
+
+  .health-pocket__content {
+    grid-template-columns: 1fr;
+  }
+
+  .health-pocket .score-ring {
+    justify-self: start;
+  }
+
+  .ledger-panel .receipts,
+  .ledger-panel .history-list {
+    grid-template-columns: 1fr;
+  }
+
+  .spotlight-panel .observer-map {
+    min-height: 320px;
+  }
+}
+
+body[data-ui-theme="light"] {
+  --bg: #fff9f3;
+  --bg-deep: #fffdf9;
+  --bg-alt: #f3ebff;
+  --panel: rgba(255, 255, 255, 0.76);
+  --panel-strong: rgba(247, 251, 255, 0.96);
+  --panel-soft: rgba(36, 81, 255, 0.1);
+  --panel-overlay: linear-gradient(180deg, rgba(255, 255, 255, 0.42), rgba(255, 255, 255, 0.12));
+  --line: rgba(27, 29, 34, 0.12);
+  --line-strong: rgba(27, 29, 34, 0.22);
+  --text: #171317;
+  --muted: #6d6270;
+  --muted-strong: #463e4b;
+  --accent: #2451ff;
+  --accent-strong: #1425a5;
+  --good: #14b86a;
+  --good-glow: rgba(20, 184, 106, 0.28);
+  --fair: #ffb300;
+  --fair-glow: rgba(255, 179, 0, 0.22);
+  --poor: #ff4f5e;
+  --poor-glow: rgba(255, 79, 94, 0.24);
+  --shadow: 0 22px 70px rgba(71, 48, 81, 0.16);
+  --ring-color: #2451ff;
+  --hero-violet: #d1a3f4;
+  --hero-coral: #ff4f5e;
+  --hero-lime: #dfff00;
+  --hero-blue: #2451ff;
+  background:
+    radial-gradient(circle at 6% 0%, rgba(209, 163, 244, 0.62), transparent 32%),
+    radial-gradient(circle at 100% 8%, rgba(223, 255, 0, 0.5), transparent 24%),
+    radial-gradient(circle at 14% 100%, rgba(255, 79, 94, 0.26), transparent 28%),
+    linear-gradient(180deg, #fffdf9 0%, #fff7f0 54%, #fffdf8 100%);
+  color: var(--text);
+}
+
+body[data-ui-theme="light"] .splash-scene {
+  opacity: 0.76;
+}
+
+body[data-ui-theme="light"] .splash-scene__mesh {
+  background:
+    radial-gradient(circle at 16% 24%, rgba(209, 163, 244, 0.62), transparent 26%),
+    radial-gradient(circle at 78% 18%, rgba(36, 81, 255, 0.24), transparent 24%),
+    radial-gradient(circle at 62% 74%, rgba(255, 79, 94, 0.18), transparent 18%),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.22), rgba(255, 255, 255, 0));
+}
+
+body[data-ui-theme="light"] .splash-scene__beam {
+  background: radial-gradient(circle, rgba(36, 81, 255, 0.18), transparent 68%);
+}
+
+body[data-ui-theme="light"] .splash-scene__grid {
+  border-color: rgba(20, 37, 165, 0.08);
+  background:
+    linear-gradient(rgba(20, 37, 165, 0.07) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(20, 37, 165, 0.07) 1px, transparent 1px),
+    radial-gradient(circle at 50% 50%, rgba(223, 255, 0, 0.12), transparent 56%);
+}
+
+body[data-ui-theme="light"] .splash-scene__ring {
+  border-color: rgba(20, 37, 165, 0.12);
+  background: radial-gradient(circle, rgba(209, 163, 244, 0.12), transparent 70%);
+}
+
+body[data-ui-theme="light"] .splash-scene__badge {
+  border-color: rgba(20, 37, 165, 0.12);
+  background: rgba(255, 255, 255, 0.78);
+  color: #342d40;
+  box-shadow: 0 18px 40px rgba(126, 75, 109, 0.1);
+}
+
+body[data-ui-theme="light"] .splash-scene__badge::before {
+  box-shadow: 0 0 18px rgba(36, 81, 255, 0.22);
+}
+
+body[data-ui-theme="light"]::before {
+  background:
+    linear-gradient(rgba(20, 37, 165, 0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(20, 37, 165, 0.04) 1px, transparent 1px);
+  opacity: 0.7;
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.42), transparent 100%);
+}
+
+body[data-ui-theme="light"]::after {
+  background:
+    radial-gradient(circle at 20% 20%, rgba(36, 81, 255, 0.18), transparent 22%),
+    radial-gradient(circle at 80% 35%, rgba(255, 79, 94, 0.14), transparent 18%),
+    radial-gradient(circle at 50% 70%, rgba(223, 255, 0, 0.14), transparent 18%);
+  opacity: 0.9;
+  filter: blur(72px);
+}
+
+body[data-ui-theme="light"] .screen-glow {
+  background: radial-gradient(circle, rgba(209, 163, 244, 0.22), transparent 72%);
+}
+
+body[data-ui-theme="light"] :focus-visible {
+  outline-color: rgba(49, 94, 208, 0.78);
+}
+
+body[data-ui-theme="light"] code {
+  border-color: rgba(35, 73, 166, 0.1);
+  background: rgba(74, 120, 255, 0.08);
+  color: #2349a6;
+}
+
+body[data-ui-theme="light"] .hero-stage {
+  border-color: rgba(23, 19, 23, 0.12);
+  background:
+    radial-gradient(circle at 14% 2%, rgba(209, 163, 244, 0.92), transparent 34%),
+    radial-gradient(circle at 84% 102%, rgba(255, 79, 94, 0.84), transparent 30%),
+    radial-gradient(circle at 64% 90%, rgba(223, 255, 0, 0.86), transparent 16%),
+    linear-gradient(140deg, rgba(255, 255, 255, 0.94), rgba(250, 246, 255, 0.92) 54%, rgba(255, 249, 243, 0.98));
+  box-shadow: 0 28px 80px rgba(126, 75, 109, 0.18);
+}
+
+body[data-ui-theme="light"] .pill,
+body[data-ui-theme="light"] .dock-meta__item,
+body[data-ui-theme="light"] .observer-pill .status,
+body[data-ui-theme="light"] .timeline-track,
+body[data-ui-theme="light"] .meter-track,
+body[data-ui-theme="light"] .score-ring,
+body[data-ui-theme="light"] .action-menu__panel,
+body[data-ui-theme="light"] .drawer-head,
+body[data-ui-theme="light"] .drawer-scrim {
+  border-color: rgba(43, 76, 124, 0.12);
+}
+
+body[data-ui-theme="light"] .pill,
+body[data-ui-theme="light"] .dock-meta__item,
+body[data-ui-theme="light"] .observer-pill .status,
+body[data-ui-theme="light"] .action-menu__panel,
+body[data-ui-theme="light"] .drawer-head {
+  background: rgba(255, 255, 255, 0.84);
+  color: var(--text);
+}
+
+body[data-ui-theme="light"] .drawer-scrim {
+  background: rgba(157, 177, 214, 0.28);
+}
+
+body[data-ui-theme="light"] .brand-orb {
+  border-color: rgba(20, 37, 165, 0.14);
+  background:
+    linear-gradient(145deg, rgba(36, 81, 255, 0.22), rgba(223, 255, 0, 0.16)),
+    rgba(255, 255, 255, 0.7);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.48),
+    0 0 24px rgba(36, 81, 255, 0.12);
+}
+
+body[data-ui-theme="light"] .brand-orb span {
+  border-color: rgba(20, 37, 165, 0.18);
+}
+
+body[data-ui-theme="light"] .brand-orb::after {
+  background: radial-gradient(circle, rgba(36, 81, 255, 0.44), transparent 72%);
+}
+
+body[data-ui-theme="light"] .score-ring {
+  background: radial-gradient(circle, rgba(74, 120, 255, 0.08), transparent 68%);
+}
+
+body[data-ui-theme="light"] .score-ring__track {
+  stroke: rgba(43, 76, 124, 0.12);
+}
+
+body[data-ui-theme="light"] .status-pill::before {
+  box-shadow: 0 0 14px rgba(217, 78, 98, 0.18);
+}
+
+body[data-ui-theme="light"] .status-pill.online::before {
+  box-shadow: 0 0 16px rgba(32, 175, 116, 0.18);
+}
+
+body[data-ui-theme="light"] .sparkline[data-tone="neutral"] .sparkline-bar {
+  background: linear-gradient(180deg, rgba(96, 114, 138, 0.32), rgba(96, 114, 138, 0.08));
+}
+
+body[data-ui-theme="light"] .timeline-track,
+body[data-ui-theme="light"] .meter-track {
+  background: rgba(43, 76, 124, 0.08);
+}
+
+body[data-ui-theme="light"] .timeline-fill {
+  background: linear-gradient(90deg, rgba(74, 120, 255, 0.26), rgba(74, 120, 255, 0.1));
+}
+
+body[data-ui-theme="light"] .timeline-dot {
+  border-color: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 0 16px rgba(74, 120, 255, 0.18);
+}
+
+body[data-ui-theme="light"] .action-menu__button,
+body[data-ui-theme="light"] .action-menu__item {
+  color: #3b355f;
+}
+
+body[data-ui-theme="light"] .site-footer a,
+body[data-ui-theme="light"] .hash-link {
+  color: #2451ff;
+}
+
+body[data-ui-theme="light"] .hero-stage::before {
+  background:
+    linear-gradient(125deg, rgba(255, 255, 255, 0.42), transparent 28%),
+    repeating-linear-gradient(90deg, rgba(20, 37, 165, 0.045) 0 1px, transparent 1px 96px);
+}
+
+body[data-ui-theme="light"] .hero-stage::after {
+  background: radial-gradient(circle, rgba(255, 79, 94, 0.22), transparent 72%);
+}
+
+body[data-ui-theme="light"] .hero-stage__brief {
+  border-color: rgba(23, 19, 23, 0.12);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.26), rgba(223, 255, 0, 0.08) 100%);
+}
+
+body[data-ui-theme="light"] .telemetry-strip {
+  border-top-color: rgba(23, 19, 23, 0.12);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.42), rgba(255, 255, 255, 0.16));
+}
+
+body[data-ui-theme="light"] .telemetry-strip__item,
+body[data-ui-theme="light"] .hero-stage__action-rail,
+body[data-ui-theme="light"] .marquee-panel,
+body[data-ui-theme="light"] .spotlight-panel,
+body[data-ui-theme="light"] .observer-panel,
+body[data-ui-theme="light"] .ledger-panel,
+body[data-ui-theme="light"] .panel,
+body[data-ui-theme="light"] .hero-panel,
+body[data-ui-theme="light"] .glance-card,
+body[data-ui-theme="light"] .detail-drawer {
+  border-color: rgba(43, 76, 124, 0.1);
+  color: var(--text);
+}
+
+body[data-ui-theme="light"] .telemetry-strip__item {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.78), rgba(248, 245, 255, 0.54));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.52);
+}
+
+body[data-ui-theme="light"] .telemetry-strip__item:nth-child(1) {
+  background: linear-gradient(180deg, rgba(36, 81, 255, 0.18), rgba(255, 255, 255, 0.76));
+}
+
+body[data-ui-theme="light"] .telemetry-strip__item:nth-child(2) {
+  background: linear-gradient(180deg, rgba(223, 255, 0, 0.34), rgba(255, 255, 255, 0.76));
+}
+
+body[data-ui-theme="light"] .telemetry-strip__item:nth-child(3) {
+  background: linear-gradient(180deg, rgba(255, 79, 94, 0.18), rgba(255, 255, 255, 0.78));
+}
+
+body[data-ui-theme="light"] .telemetry-strip__item:nth-child(4) {
+  background: linear-gradient(180deg, rgba(209, 163, 244, 0.28), rgba(255, 255, 255, 0.76));
+}
+
+body[data-ui-theme="light"] .marquee-panel,
+body[data-ui-theme="light"] .spotlight-panel,
+body[data-ui-theme="light"] .observer-panel,
+body[data-ui-theme="light"] .ledger-panel {
+  box-shadow: 0 18px 54px rgba(126, 75, 109, 0.14);
+}
+
+body[data-ui-theme="light"] .marquee-panel {
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.9), rgba(255, 248, 236, 0.84) 52%, rgba(223, 255, 0, 0.2));
+  box-shadow:
+    0 18px 54px rgba(126, 75, 109, 0.14),
+    inset 0 4px 0 rgba(255, 79, 94, 0.72);
+}
+
+body[data-ui-theme="light"] .spotlight-panel {
+  background:
+    linear-gradient(180deg, rgba(244, 248, 255, 0.9), rgba(227, 237, 255, 0.82));
+  box-shadow:
+    0 18px 54px rgba(126, 75, 109, 0.14),
+    inset 0 4px 0 rgba(36, 81, 255, 0.72);
+}
+
+body[data-ui-theme="light"] .observer-panel {
+  background:
+    linear-gradient(180deg, rgba(252, 255, 222, 0.92), rgba(246, 255, 195, 0.82));
+  box-shadow:
+    0 18px 54px rgba(126, 75, 109, 0.14),
+    inset 0 4px 0 rgba(223, 255, 0, 0.96);
+}
+
+body[data-ui-theme="light"] .ledger-panel {
+  background:
+    linear-gradient(180deg, rgba(252, 245, 255, 0.92), rgba(255, 240, 244, 0.84));
+  box-shadow:
+    0 18px 54px rgba(126, 75, 109, 0.14),
+    inset 0 4px 0 rgba(209, 163, 244, 0.86);
+}
+
+body[data-ui-theme="light"] .marquee-panel::after {
+  background: radial-gradient(circle, rgba(36, 81, 255, 0.18), transparent 70%);
+}
+
+body[data-ui-theme="light"] .health-pocket,
+body[data-ui-theme="light"] .message-preview,
+body[data-ui-theme="light"] .ledger-divider,
+body[data-ui-theme="light"] .panel-divider,
+body[data-ui-theme="light"] .hero-stage__brief,
+body[data-ui-theme="light"] .telemetry-strip__item {
+  border-color: rgba(43, 76, 124, 0.12);
+}
+
+body[data-ui-theme="light"] .ghost-button,
+body[data-ui-theme="light"] .panel-lens {
+  border-color: rgba(20, 37, 165, 0.12);
+  background: rgba(255, 255, 255, 0.78);
+  color: #2f2944;
+}
+
+body[data-ui-theme="light"] .primary-button {
+  border-color: rgba(255, 79, 94, 0.24);
+  background: linear-gradient(135deg, #ff5b67, #ff4352);
+  color: #ffffff;
+  box-shadow: 0 12px 28px rgba(255, 79, 94, 0.24);
+}
+
+body[data-ui-theme="light"] .ghost-button:hover,
+body[data-ui-theme="light"] .ghost-button:focus-visible,
+body[data-ui-theme="light"] .panel-lens:hover,
+body[data-ui-theme="light"] .panel-lens:focus-visible {
+  border-color: rgba(20, 37, 165, 0.22);
+  background: rgba(36, 81, 255, 0.1);
+  color: #1425a5;
+}
+
+body[data-ui-theme="light"] .primary-button:hover,
+body[data-ui-theme="light"] .primary-button:focus-visible {
+  border-color: rgba(255, 79, 94, 0.32);
+  box-shadow: 0 16px 34px rgba(255, 79, 94, 0.3);
+}
+
+body[data-ui-theme="light"] .dock-nav__item {
+  border-color: rgba(20, 37, 165, 0.08);
+  background: rgba(255, 255, 255, 0.64);
+  color: #342d40;
+}
+
+body[data-ui-theme="light"] .dock-nav__item span {
+  border-color: rgba(20, 37, 165, 0.16);
+  background: rgba(36, 81, 255, 0.14);
+  color: #1425a5;
+}
+
+body[data-ui-theme="light"] .dock-nav__item:nth-child(2) span {
+  border-color: rgba(143, 164, 0, 0.2);
+  background: rgba(223, 255, 0, 0.36);
+  color: #494100;
+}
+
+body[data-ui-theme="light"] .dock-nav__item:nth-child(3) span {
+  border-color: rgba(255, 79, 94, 0.18);
+  background: rgba(255, 79, 94, 0.18);
+  color: #9c2230;
+}
+
+body[data-ui-theme="light"] .dock-nav__item:nth-child(4) span {
+  border-color: rgba(137, 73, 196, 0.2);
+  background: rgba(209, 163, 244, 0.3);
+  color: #6f2ea8;
+}
+
+body[data-ui-theme="light"] .metric-card,
+body[data-ui-theme="light"] .history-item,
+body[data-ui-theme="light"] .receipt-card,
+body[data-ui-theme="light"] .observer-option,
+body[data-ui-theme="light"] .observer-pill,
+body[data-ui-theme="light"] .empty-state,
+body[data-ui-theme="light"] .drawer-card,
+body[data-ui-theme="light"] .drawer-stat,
+body[data-ui-theme="light"] .drawer-list__item,
+body[data-ui-theme="light"] .console-line,
+body[data-ui-theme="light"] .timeline-row {
+  border-color: rgba(23, 19, 23, 0.08);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.68), rgba(248, 251, 255, 0.46)),
+    rgba(255, 255, 255, 0.42);
+}
+
+body[data-ui-theme="light"] .session-code {
+  border-color: rgba(20, 37, 165, 0.16);
+  background:
+    linear-gradient(135deg, rgba(36, 81, 255, 0.16), rgba(209, 163, 244, 0.08)),
+    rgba(255, 255, 255, 0.86);
+  color: #1425a5;
+}
+
+body[data-ui-theme="light"] .observer-map {
+  border-color: rgba(43, 76, 124, 0.12);
+}
+
+body[data-ui-theme="light"] .leaflet-container {
+  background: linear-gradient(180deg, rgba(231, 240, 255, 0.96), rgba(245, 249, 255, 0.98));
+}
+
+body[data-ui-theme="light"] .leaflet-control-zoom a,
+body[data-ui-theme="light"] .leaflet-control-attribution {
+  border-color: rgba(43, 76, 124, 0.12) !important;
+  background: rgba(255, 255, 255, 0.86) !important;
+  color: #2349a6 !important;
+}
+
+body[data-ui-theme="light"] .leaflet-popup-content-wrapper,
+body[data-ui-theme="light"] .leaflet-popup-tip {
+  background: rgba(255, 255, 255, 0.96);
+  color: var(--text);
+  border-color: rgba(43, 76, 124, 0.12);
+  box-shadow: 0 18px 36px rgba(53, 84, 133, 0.14);
+}
+
+body[data-ui-theme="light"] .drawer-codeblock {
+  border-color: rgba(43, 76, 124, 0.08);
+  background: rgba(245, 249, 255, 0.92);
+  color: #2349a6;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }

--- a/server.js
+++ b/server.js
@@ -2147,8 +2147,8 @@ app.get('/manifest.webmanifest', (request, response) => {
     scope: '/',
     display: 'standalone',
     display_override: ['standalone', 'minimal-ui'],
-    background_color: '#101512',
-    theme_color: '#101512',
+    background_color: '#07111d',
+    theme_color: '#07111d',
     icons: [
       {
         src: '/logo.png',

--- a/test/smoke/dashboard.spec.js
+++ b/test/smoke/dashboard.spec.js
@@ -10,7 +10,8 @@ test('dashboard loads and creates a session code', async ({ page }) => {
   await expect(page.locator('#session-code')).toContainText('MHC-', { timeout: 10000 });
   await expect(page.getByRole('button', { name: 'Copy' })).toBeVisible();
   await expect(page.getByText('Where the observers are')).toBeVisible();
-  await expect(page.locator('#map-observer-note')).toContainText('Waiting for observer coordinates.');
+  await expect(page.locator('#map-observer-note')).toContainText('mapped observers reached.');
+  await expect(page.locator('#observer-map')).toBeVisible();
   await expect(page.getByText('When each observer saw it')).toBeVisible();
   await expect(page.getByText('Timeline appears after the first observer report.')).toBeVisible();
 });


### PR DESCRIPTION
## What changed

This PR prepares the UI branch for merge into `dev` as `v1.2.5`.

It includes:
- the redesigned dashboard shell and hero treatment
- the redesigned shared-result page and landing flow
- the new control-center layout across the UI
- the `Repeaters` metric carried forward from `v1.2.4` into the redesigned score cards
- mobile/layout cleanup needed to make the redesigned shell usable across dashboard and share views
- light-theme cleanup so the redesigned UI has a coherent light mode instead of the earlier saturated placeholder styling

## Version scope

This branch is now intended to land as `v1.2.5`.

Release-level `v1.2.5` changes are:
- redesigned dashboard, share, and landing experience
- redesigned score presentation with repeater count integrated
- shared-result view brought onto the same new UI system as the main dashboard

## Why it changed

The previous UI worked functionally but still felt like an accumulation of incremental passes. This branch consolidates the redesign work into a coherent shell that is ready to merge on top of the current `dev` branch and current `v1.2.4` repeater-count feature set.

## Merge readiness

This branch has been rebased onto current `dev`, conflicts were resolved locally, and the redesigned UI is now aligned with the current versioned app state.

## Validation

- `npm run check`
- `npm test`
- `docker compose up -d --build`
- `curl -s http://localhost:3090/api/bootstrap`

## Notes

This PR targets `dev` and is prepared for the `v1.2.5` merge path.