### PR TITLE
release: v1.3.8

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ APP_HEADLINE=Check your mesh reach.
 APP_DESCRIPTION=Generate a test code, send it to the configured channel, and watch observer coverage build in real time.
 SITE_URL=
 CORESCOPE_URL=
+# Public CARTO browser key used for Dark Matter map tiles. Leave blank to use
+# OpenStreetMap tiles while retaining the dark dashboard theme.
+CARTO_BASEMAP_KEY=
 EXTERNAL_LINK_URL=
 EXTERNAL_LINK_LABEL=
 LOG_LEVEL=info

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Changes
 
+## v1.3.8
+
+- added `CARTO_BASEMAP_KEY` support for authenticated CARTO Dark Matter map
+  tiles and exposed the public project key through `/api/bootstrap`
+- changed dark-theme map rendering to fall back to OpenStreetMap when no CARTO
+  key is configured instead of requesting unavailable keyless CARTO tiles
+- updated the Docker runtime from Node `22-slim` to `26-slim`
+
 ## v1.3.7
 
 - changed the coverage map to follow the active session's expected observer set

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-slim
+FROM node:26-slim
 
 WORKDIR /app
 

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -15,11 +15,16 @@ in source files.
 | `APP_DESCRIPTION` | Generated coverage description | Site description and social metadata. |
 | `SITE_URL` | blank | Public site URL used for generated absolute share links and social metadata. Set this when running behind a reverse proxy. |
 | `CORESCOPE_URL` | blank | Optional CoreScope root URL. When set, matched message hashes link to `#/packets/<hash>`. |
+| `CARTO_BASEMAP_KEY` | blank | Public browser key for CARTO Dark Matter map tiles. Without it, the map uses OpenStreetMap tiles while the dashboard can remain in dark mode. |
 | `EXTERNAL_LINK_URL` | blank | Optional HTTP(S) hero/control-center external link URL. Other URL schemes are rejected. |
 | `EXTERNAL_LINK_LABEL` | blank | Label for the optional external link. |
 | `LOG_LEVEL` | `info` | Use `debug` only while troubleshooting ingest or decode behavior. |
 | `TRUST_PROXY` | `1` | Express proxy trust setting. Use `1` behind one trusted reverse proxy or `false` for direct access so client IP rate limits cannot be spoofed with forwarded headers. |
 | `DISTANCE_UNIT` | `mi` | Distance labels for packet-path estimates. Use `mi` or `km`. |
+
+As of August 2026, CARTO requires an API key for Dark Matter raster tiles. Keep
+the project key in `.env`, not Git. CARTO's browser integration exposes the key
+in tile request URLs, so scope it to this project and its deployment hostnames.
 
 ## Storage
 

--- a/HOWTO.md
+++ b/HOWTO.md
@@ -48,12 +48,26 @@ cp .env.example .env
   observers from packet history
 - set `REGIONS_FILE` if you want region buttons above the observer selector
 - set `SITE_URL` to the public HTTPS origin when running behind a reverse proxy
+- set `CARTO_BASEMAP_KEY` to enable CARTO Dark Matter tiles for the coverage map
 - keep `TRUST_PROXY=1` behind one trusted reverse proxy, or set it to `false`
   when exposing the app directly
 - enable Turnstile if the site is internet-facing
 - leave `LOG_LEVEL=info` unless actively troubleshooting
 
 See [ENVIRONMENT.md](ENVIRONMENT.md) for the full variable reference.
+
+CARTO now requires a project API key for its Dark Matter raster tiles. Request
+one from <https://carto.com/basemaps/apikey/>, register every hostname that will
+serve this deployment (including `localhost` when needed), and put the key only
+in `.env`:
+
+```env
+CARTO_BASEMAP_KEY=your-carto-key
+```
+
+The key is intentionally visible in browser tile requests, so do not reuse it
+outside this project. If it is blank, the dashboard still supports its dark UI
+theme but the coverage map falls back to OpenStreetMap tiles.
 
 4. Start the service:
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ At minimum, configure MQTT and the test channel in `.env`:
 - `MQTT_TOPIC`
 - `TEST_CHANNEL_NAME`
 - `TEST_CHANNEL_SECRET` or `TEST_CHANNEL_HASH`
+- `CARTO_BASEMAP_KEY` to enable CARTO Dark Matter coverage-map tiles
 
 For full setup steps, read [HOWTO.md](HOWTO.md). For every runtime variable,
 read [ENVIRONMENT.md](ENVIRONMENT.md).
@@ -90,6 +91,8 @@ read [ENVIRONMENT.md](ENVIRONMENT.md).
   change the actual MQTT connection.
 - `CORESCOPE_URL` changes the matched message-hash link to CoreScope
   `#/packets/<hash>` routes.
+- `CARTO_BASEMAP_KEY` enables CARTO Dark Matter tiles. Without it, the coverage
+  map falls back to OpenStreetMap while the dark dashboard theme remains usable.
 - `DISTANCE_UNIT=mi` or `DISTANCE_UNIT=km` controls packet distance labels.
 
 ## Validation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mesh-health-check",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mesh-health-check",
-      "version": "1.3.7",
+      "version": "1.3.8",
       "hasInstallScript": true,
       "dependencies": {
         "@michaelhart/meshcore-decoder": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mesh-health-check",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "private": true,
   "type": "module",
   "description": "MeshCore observer health checker for #health-check message propagation",

--- a/public/app.js
+++ b/public/app.js
@@ -1335,13 +1335,16 @@ function currentTileLayer() {
   if (!window.L) {
     return null;
   }
-  if (state.uiTheme === 'light') {
+  const cartoBasemapKey = String(state.snapshot?.map?.cartoBasemapKey || '').trim();
+  if (state.uiTheme === 'light' || !cartoBasemapKey) {
     return window.L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
       maxZoom: 19,
       attribution: '&copy; OpenStreetMap contributors',
     });
   }
-  return window.L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+  const tileUrl = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png'
+    + `?key=${encodeURIComponent(cartoBasemapKey)}`;
+  return window.L.tileLayer(tileUrl, {
     maxZoom: 19,
     subdomains: 'abcd',
     attribution: '&copy; OpenStreetMap contributors &copy; CARTO',

--- a/server.js
+++ b/server.js
@@ -343,6 +343,7 @@ const APP_DESCRIPTION = envValue(
 );
 const SITE_URL = normalizeSiteUrl(envValue('SITE_URL', ''));
 const CORESCOPE_URL = normalizeSiteUrl(envValue('CORESCOPE_URL', ''));
+const CARTO_BASEMAP_KEY = envValue('CARTO_BASEMAP_KEY', '');
 const DISTANCE_UNIT = normalizeDistanceUnit(envValue('DISTANCE_UNIT', 'mi'));
 const PWA_APP_NAME = 'Mesh Reach';
 const REPO_URL = 'https://github.com/yellowcooln/meshcore-health-check';
@@ -2363,6 +2364,10 @@ function snapshotPayload() {
       connected: mqttConnected,
       broker: dashboardBrokerHost,
       topics: MQTT_TOPICS,
+    },
+    map: {
+      cartoBasemapKey: CARTO_BASEMAP_KEY,
+      darkBasemapAvailable: Boolean(CARTO_BASEMAP_KEY),
     },
     turnstile: {
       enabled: TURNSTILE_ENABLED,

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -30,6 +30,7 @@ process.env.APP_EYEBROW = 'MeshCore Observer Coverage';
 process.env.APP_DESCRIPTION = 'Generate a test code, send it to the configured channel, and watch observer coverage build in real time.';
 process.env.DASH_BROKER_HOST = 'mqtt.example.test:443';
 process.env.CORESCOPE_URL = 'https://analyzer.example.test';
+process.env.CARTO_BASEMAP_KEY = 'test-carto-key';
 process.env.EXTERNAL_LINK_URL = 'javascript:alert(1)';
 process.env.TEST_CHANNEL_NAME = 'health-check';
 process.env.TEST_CHANNEL_SECRET = 'E6D973AAC5101145AD3A3F3A0B3D52EB';
@@ -117,7 +118,7 @@ test('GET /api/bootstrap returns site and channel configuration', async () => {
 
   const payload = await response.json();
   assert.equal(payload.site.title, 'MeshCore Observer Coverage');
-  assert.equal(payload.site.version, '1.3.7');
+  assert.equal(payload.site.version, '1.3.8');
   assert.equal(payload.site.coreScopeUrl, 'https://analyzer.example.test');
   assert.equal(payload.site.externalLinkUrl, '');
   assert.equal(payload.testChannel.name, 'health-check');
@@ -126,6 +127,8 @@ test('GET /api/bootstrap returns site and channel configuration', async () => {
   assert.equal(payload.mqtt.broker, 'mqtt.example.test:443');
   assert.equal(payload.results.retentionSeconds, 604800);
   assert.equal(payload.observerStats.hashDisplayBytes, 1);
+  assert.equal(payload.map.cartoBasemapKey, 'test-carto-key');
+  assert.equal(payload.map.darkBasemapAvailable, true);
 });
 
 test('GET /app includes server-rendered social meta tags', async () => {

--- a/test/smoke/dashboard.spec.js
+++ b/test/smoke/dashboard.spec.js
@@ -24,18 +24,22 @@ function mapObserver(key, label, lat, lon, region) {
   };
 }
 
-function mapBootstrap(observerDirectory) {
+function mapBootstrap(observerDirectory, cartoBasemapKey = 'test-carto-key') {
   return {
     site: {
       title: 'MeshCore Observer Coverage',
       eyebrow: 'MeshCore Observer Coverage',
       headline: 'Check your mesh reach.',
       description: 'Generate a test code, send it to the configured channel, and watch observer coverage build in real time.',
-      version: '1.3.7',
+      version: '1.3.8',
       repoUrl: 'https://github.com/yellowcooln/meshcore-health-check',
       changesUrl: 'https://github.com/yellowcooln/meshcore-health-check/blob/main/CHANGES.md',
     },
     mqtt: { connected: false, broker: 'mqtt.example.test', topics: ['meshcore/BOS/#'] },
+    map: {
+      cartoBasemapKey,
+      darkBasemapAvailable: Boolean(cartoBasemapKey),
+    },
     testChannel: { name: 'health-check', hash: '99' },
     turnstile: { enabled: false, verified: true },
     defaultObserverSource: 'configured',
@@ -87,7 +91,12 @@ function mapSession(expectedObservers) {
   };
 }
 
-async function openMockMapSession(page, observerDirectory, expectedObservers) {
+async function openMockMapSession(
+  page,
+  observerDirectory,
+  expectedObservers,
+  cartoBasemapKey = 'test-carto-key',
+) {
   await page.addInitScript(() => {
     window.WebSocket = class {
       addEventListener() {}
@@ -96,7 +105,7 @@ async function openMockMapSession(page, observerDirectory, expectedObservers) {
   });
   await page.route('**/api/bootstrap', (route) => route.fulfill({
     contentType: 'application/json',
-    body: JSON.stringify(mapBootstrap(observerDirectory)),
+    body: JSON.stringify(mapBootstrap(observerDirectory, cartoBasemapKey)),
   }));
   await page.route('**/api/sessions/map-session', (route) => route.fulfill({
     contentType: 'application/json',
@@ -177,6 +186,41 @@ test('coverage map omits observers with 0,0 coordinates', async ({ page }) => {
 
   await expect(page.locator('#map-observer-note')).toHaveText('0/1 mapped observers reached.');
   await expect(page.locator('#observer-map .leaflet-marker-icon')).toHaveCount(1);
+});
+
+test('dark coverage map sends the configured CARTO API key', async ({ page }) => {
+  const target = mapObserver(MAP_TEST_KEYS.target, 'Target Observer', 42.3601, -71.0589, 'BOS');
+  const cartoRequests = [];
+  await page.route('https://*.basemaps.cartocdn.com/**', async (route) => {
+    cartoRequests.push(route.request().url());
+    await route.abort();
+  });
+
+  await openMockMapSession(page, [target], [target]);
+
+  await expect.poll(() => cartoRequests.length).toBeGreaterThan(0);
+  expect(cartoRequests[0]).toContain('dark_all');
+  expect(cartoRequests[0]).toContain('key=test-carto-key');
+});
+
+test('dark dashboard falls back to OpenStreetMap without a CARTO key', async ({ page }) => {
+  const target = mapObserver(MAP_TEST_KEYS.target, 'Target Observer', 42.3601, -71.0589, 'BOS');
+  const cartoRequests = [];
+  const osmRequests = [];
+  await page.route('https://*.basemaps.cartocdn.com/**', async (route) => {
+    cartoRequests.push(route.request().url());
+    await route.abort();
+  });
+  await page.route('https://*.tile.openstreetmap.org/**', async (route) => {
+    osmRequests.push(route.request().url());
+    await route.abort();
+  });
+
+  await openMockMapSession(page, [target], [target], '');
+
+  await expect.poll(() => osmRequests.length).toBeGreaterThan(0);
+  expect(cartoRequests).toHaveLength(0);
+  await expect(page.locator('body')).toHaveAttribute('data-ui-theme', 'dark');
 });
 
 test('escapes untrusted observer labels in timeline and map popups', async ({ page }) => {


### PR DESCRIPTION
## Summary

- Release v1.3.8 with configurable CARTO Dark Matter support for the observer coverage map.
- Add the public `CARTO_BASEMAP_KEY` setting to `/api/bootstrap` and URL-encode it in browser tile requests.
- Fall back to OpenStreetMap tiles when no CARTO key is configured while keeping the dashboard's dark UI theme available.
- Update the Docker runtime from `node:22-slim` to `node:26-slim` through Dependabot PR #48.
- Add API and browser regression coverage for keyed CARTO requests and the no-key OpenStreetMap fallback.

## Configuration and compatibility

- Adds `CARTO_BASEMAP_KEY`; existing deployments without it continue to work and use OpenStreetMap for the coverage map.
- The CARTO key stays in the deployment `.env` and is absent from tracked files.
- Browser tile requests expose the project key by design under CARTO's Leaflet integration, so it should remain scoped to this project and its deployment hostnames.
- Existing MQTT, channel, observer, Turnstile, CoreScope, and retained-result configuration remains compatible.

## Documentation

- Updated README, HOWTO, environment reference, example environment, and release changelog for v1.3.8.
- Added CARTO key request and deployment guidance, including browser visibility and no-key behavior.
- Kept CARTO support framed as newly added v1.3.8 functionality.

## Verification

- [x] `npm run check`
- [x] `npm test` — 41 passed
- [x] `npm run test:smoke` — 9 passed
- [x] `npm outdated --json` — no available direct dependency updates
- [x] `npm audit` — 0 vulnerabilities across 126 resolved dependencies
- [x] Docker Compose image rebuilt and local container recreated successfully
- [x] Running container reports Node `v26.7.0`
- [x] Live `/api/bootstrap` reports v1.3.8 with CARTO enabled
- [x] Live browser verification initialized Leaflet in dark mode and confirmed keyed CARTO tile requests
- [x] No-key browser regression confirms OpenStreetMap fallback with no CARTO requests
- [x] `git diff --check` passed
